### PR TITLE
fix: wire up Wayland input-method backend and CI generator

### DIFF
--- a/cmd/pf/autogen_gen.go
+++ b/cmd/pf/autogen_gen.go
@@ -34,7 +34,6 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 
 	// grab: wrapper for perfuncted.Grab
 	var cmd_screen_grab_rect string
-	var cmd_screen_grab_out string
 	cmd_screen_grab := &cobra.Command{
 		Use:   "grab",
 		Short: "Auto-generated wrapper for perfuncted.Grab",
@@ -74,7 +73,6 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 	cmds = append(cmds, cmd_screen_grab)
 
 	// grab-full: wrapper for perfuncted.GrabFull
-	var cmd_screen_grab_full_out string
 
 	cmd_screen_grab_full := &cobra.Command{
 		Use:   "grab-full",

--- a/cmd/pf/autogen_gen.go
+++ b/cmd/pf/autogen_gen.go
@@ -34,6 +34,7 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 
 	// grab: wrapper for perfuncted.Grab
 	var cmd_screen_grab_rect string
+	var cmd_screen_grab_out string
 	cmd_screen_grab := &cobra.Command{
 		Use:   "grab",
 		Short: "Auto-generated wrapper for perfuncted.Grab",
@@ -73,7 +74,7 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 	cmds = append(cmds, cmd_screen_grab)
 
 	// grab-full: wrapper for perfuncted.GrabFull
-
+	var cmd_screen_grab_full_out string
 	cmd_screen_grab_full := &cobra.Command{
 		Use:   "grab-full",
 		Short: "Auto-generated wrapper for perfuncted.GrabFull",

--- a/scripts/gen_cli.go
+++ b/scripts/gen_cli.go
@@ -416,6 +416,18 @@ func main() {
 			}
 
 			// start command variable
+			// If this command produces an image, add an "out" flag variable so
+			// the flags registration below can reference it when generating the
+			// StringVar call.
+			if produce == "image" {
+				outFlag := "out"
+				if mapping[grp] != nil {
+					if mm, ok := mapping[grp][mn]; ok && mm.OutFlag != "" {
+						outFlag = mm.OutFlag
+					}
+				}
+				flagVars = append(flagVars, fmt.Sprintf("var %s_%s string", cmdVar, outFlag))
+			}
 			sb.WriteString("\t" + strings.Join(flagVars, "\n\t") + "\n")
 			sb.WriteString(fmt.Sprintf("\t%s := &cobra.Command{\n", cmdVar))
 			sb.WriteString(fmt.Sprintf("\t\tUse:   \"%s\",\n", cliName))


### PR DESCRIPTION
This PR:

- Wires NewWlInputMethodBackend into input.Open so the layout-independent input-method path (commit_string) is used for typing on Wayland.
- Reorders CI so docs/CLI generation runs before vet/build to avoid churn from generated files.
- Fixes scripts/gen_cli.go (declares image output flag vars) and regenerates cmd/pf/autogen_gen.go.

Local tests: go test ./... passed.