### PR TITLE
Own nested integration sessions

### DIFF
--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -5,7 +5,7 @@
 // Usage:
 //
 //	go run ./cmd/integration --headless   # Start an isolated session and run tests
-//	go run ./cmd/integration --nested     # Auto-detect and run against nested session
+//	go run ./cmd/integration --nested     # Start and run against a nested session
 //	go run ./cmd/integration --app kwrite # Run tests only for kwrite
 package main
 
@@ -42,7 +42,7 @@ const (
 
 func main() {
 	headless := flag.Bool("headless", false, "start a new isolated headless sway session for the test")
-	nested := flag.Bool("nested", false, "connect to an existing nested sway session in /tmp")
+	nested := flag.Bool("nested", false, "start a nested sway session for the test")
 	appFilter := flag.String("app", "", "run only this app (kwrite, pluma, firefox); empty = all")
 	flag.Parse()
 
@@ -61,32 +61,32 @@ func main() {
 			log.Fatalf("failed to start headless session: %v", err)
 		}
 		defer sess.Stop()
+		defer sess.CleanupOnSignal(context.Background())()
 		fmt.Printf("  session ready (XDG=%s)\n", sess.XDGRuntimeDir())
 		targetRuntime = targetRuntime.WithSession(sess.XDGRuntimeDir(), sess.WaylandDisplay(), sess.DBusAddress())
 	} else if *nested {
 		mode = modeNested
+		fmt.Println("▶ starting nested session...")
+		sess, err = perfuncted.StartNestedSession(perfuncted.SessionConfig{
+			Resolution: image.Pt(1024, 768),
+		})
+		if err != nil {
+			log.Fatalf("failed to start nested session: %v", err)
+		}
+		defer sess.Stop()
+		defer sess.CleanupOnSignal(context.Background())()
+		fmt.Printf("  session ready (XDG=%s)\n", sess.XDGRuntimeDir())
+		targetRuntime = targetRuntime.WithSession(sess.XDGRuntimeDir(), sess.WaylandDisplay(), sess.DBusAddress())
 	}
 
 	opts := perfuncted.Options{
-		Nested: *nested,
-		MaxX:   1024,
-		MaxY:   768,
+		MaxX: 1024,
+		MaxY: 768,
 	}
 	if sess != nil {
 		opts.XDGRuntimeDir = sess.XDGRuntimeDir()
 		opts.WaylandDisplay = sess.WaylandDisplay()
 		opts.DBusSessionAddress = sess.DBusAddress()
-	} else if *nested {
-		fmt.Println("▶ connecting to nested session...")
-		xdg, wl, dbus, err := perfuncted.NestedEnv()
-		if err != nil {
-			log.Fatalf("failed to find nested session: %v", err)
-		}
-		opts.XDGRuntimeDir = xdg
-		opts.WaylandDisplay = wl
-		opts.DBusSessionAddress = dbus
-		fmt.Printf("  connected to XDG=%s\n", xdg)
-		targetRuntime = targetRuntime.WithSession(xdg, wl, dbus)
 	}
 
 	pf, err := perfuncted.New(opts)

--- a/perfuncted.go
+++ b/perfuncted.go
@@ -20,6 +20,8 @@ import (
 	"github.com/nskaggs/perfuncted/window"
 )
 
+var nestedSessionGlob = filepath.Glob
+
 // Options controls backend selection.
 type Options struct {
 	MaxX, MaxY int32
@@ -53,52 +55,60 @@ func resolveRuntime(opts Options) (env.Runtime, error) {
 }
 
 func NestedEnv() (xdgRuntimeDir, waylandDisplay, dbusAddr string, err error) {
-	matches, err := filepath.Glob("/tmp/perfuncted-xdg-*")
+	matches, err := nestedSessionGlob("/tmp/perfuncted-xdg-*")
 	if err != nil {
 		return "", "", "", fmt.Errorf("perfuncted: glob nested sessions: %w", err)
 	}
 	if len(matches) == 0 {
 		return "", "", "", fmt.Errorf("perfuncted: no nested session found in /tmp/perfuncted-xdg-*")
 	}
-	if len(matches) > 1 {
-		// If multiple nested sessions exist, pick the most-recently-modified
-		// directory to be robust in CI where parallel runs may leave multiple
-		// entries. Emit a warning to stderr to help debugging.
-		type mtimeEntry struct {
-			path string
-			mod  time.Time
-		}
-		var entries []mtimeEntry
-		for _, m := range matches {
-			if fi, statErr := os.Stat(m); statErr == nil {
-				entries = append(entries, mtimeEntry{path: m, mod: fi.ModTime()})
-			} else {
-				entries = append(entries, mtimeEntry{path: m, mod: time.Time{}})
-			}
-		}
-		sort.Slice(entries, func(i, j int) bool { return entries[i].mod.After(entries[j].mod) })
-		xdgDir := entries[0].path
-		fmt.Fprintf(os.Stderr, "warning: multiple nested sessions found, picking %s\n", xdgDir)
-		matches = []string{xdgDir}
+	type nestedEntry struct {
+		path string
+		mod  time.Time
+		wl   string
 	}
 
-	xdgDir := matches[0]
+	var entries []nestedEntry
+	for _, xdgDir := range matches {
+		wlSocket, socketErr := nestedWaylandSocket(xdgDir)
+		if socketErr != nil {
+			continue
+		}
+
+		fi, statErr := os.Stat(xdgDir)
+		mod := time.Time{}
+		if statErr == nil {
+			mod = fi.ModTime()
+		}
+		entries = append(entries, nestedEntry{path: xdgDir, mod: mod, wl: wlSocket})
+	}
+	if len(entries) == 0 {
+		return "", "", "", fmt.Errorf("perfuncted: no nested session found with a wayland socket in /tmp/perfuncted-xdg-*")
+	}
+
+	if len(entries) > 1 {
+		// If multiple nested sessions exist, pick the most-recently-modified
+		// directory among the ones that actually expose a Wayland socket.
+		sort.Slice(entries, func(i, j int) bool { return entries[i].mod.After(entries[j].mod) })
+		fmt.Fprintf(os.Stderr, "warning: multiple nested sessions found, picking %s\n", entries[0].path)
+	}
+
+	xdgDir := entries[0].path
+	return xdgDir, entries[0].wl, fmt.Sprintf("unix:path=%s/bus", xdgDir), nil
+}
+
+func nestedWaylandSocket(xdgDir string) (string, error) {
 	sockets, err := filepath.Glob(filepath.Join(xdgDir, "wayland-*"))
 	if err != nil {
-		return "", "", "", fmt.Errorf("perfuncted: glob wayland sockets: %w", err)
+		return "", fmt.Errorf("perfuncted: glob wayland sockets: %w", err)
 	}
-	var wlSocket string
 	for _, sock := range sockets {
-		if !strings.HasSuffix(sock, ".lock") {
-			wlSocket = filepath.Base(sock)
-			break
+		if strings.HasSuffix(sock, ".lock") {
+			continue
 		}
+		return filepath.Base(sock), nil
 	}
-	if wlSocket == "" {
-		return "", "", "", fmt.Errorf("perfuncted: no wayland socket in %s", xdgDir)
-	}
-
-	return xdgDir, wlSocket, fmt.Sprintf("unix:path=%s/bus", xdgDir), nil
+	return "", fmt.Errorf("perfuncted: no wayland socket in %s", xdgDir)
 }
 
 func DetectSession() (kind string, details map[string]string) {

--- a/perfuncted_nested_test.go
+++ b/perfuncted_nested_test.go
@@ -1,0 +1,61 @@
+package perfuncted
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNestedEnvSkipsStaleDirsWithoutWaylandSocket(t *testing.T) {
+	validDir := mustCreateNestedSessionDir(t, true)
+	staleDir := mustCreateNestedSessionDir(t, false)
+
+	oldGlob := nestedSessionGlob
+	nestedSessionGlob = func(pattern string) ([]string, error) {
+		return []string{staleDir, validDir}, nil
+	}
+	t.Cleanup(func() {
+		nestedSessionGlob = oldGlob
+	})
+
+	xdg, wl, dbus, err := NestedEnv()
+	if err != nil {
+		t.Fatalf("NestedEnv: %v", err)
+	}
+
+	if xdg != validDir {
+		t.Fatalf("XDG_RUNTIME_DIR = %q, want %q", xdg, validDir)
+	}
+	if wl != "wayland-1" {
+		t.Fatalf("WAYLAND_DISPLAY = %q, want wayland-1", wl)
+	}
+	if dbus != "unix:path="+filepath.Join(validDir, "bus") {
+		t.Fatalf("DBusSessionAddress = %q, want unix:path=%s/bus", dbus, validDir)
+	}
+}
+
+func mustCreateNestedSessionDir(t *testing.T, withSocket bool) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+
+	if !withSocket {
+		return dir
+	}
+
+	socketPath := filepath.Join(dir, "wayland-1")
+	if err := os.WriteFile(socketPath, []byte("socket"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	return dir
+}

--- a/perfuncted_runtime_resolve_test.go
+++ b/perfuncted_runtime_resolve_test.go
@@ -1,6 +1,10 @@
 package perfuncted
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/nskaggs/perfuncted/internal/env"
+)
 
 func TestResolveRuntimePreservesHostDesktopWhenNoSessionOverride(t *testing.T) {
 	t.Setenv("DISPLAY", ":99")
@@ -41,5 +45,27 @@ func TestResolveRuntimeClearsHostDisplayForExplicitSession(t *testing.T) {
 	}
 	if got := rt.Get("SWAYSOCK"); got != "" {
 		t.Fatalf("SWAYSOCK = %q, want empty", got)
+	}
+}
+
+func TestRuntimeSocketPathResolvesRelativeWaylandDisplay(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"XDG_RUNTIME_DIR=/tmp/perfuncted-host",
+		"WAYLAND_DISPLAY=wayland-0",
+	})
+
+	if got := rt.SocketPath(); got != "/tmp/perfuncted-host/wayland-0" {
+		t.Fatalf("SocketPath = %q, want /tmp/perfuncted-host/wayland-0", got)
+	}
+}
+
+func TestRuntimeSocketPathKeepsAbsoluteWaylandDisplay(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"XDG_RUNTIME_DIR=/tmp/perfuncted-host",
+		"WAYLAND_DISPLAY=/run/user/1000/wayland-1",
+	})
+
+	if got := rt.SocketPath(); got != "/run/user/1000/wayland-1" {
+		t.Fatalf("SocketPath = %q, want /run/user/1000/wayland-1", got)
 	}
 }

--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -19,7 +19,7 @@ import (
 	"github.com/nskaggs/perfuncted/internal/executil"
 )
 
-//go:embed configs/ci.conf configs/headless.conf
+//go:embed configs/ci.conf configs/headless.conf config/sway/nested.conf
 var embeddedConfigs embed.FS
 
 // SessionConfig controls session creation.
@@ -34,6 +34,13 @@ type SessionConfig struct {
 	// LogDir is the directory for sway log output. Defaults to /tmp/perfuncted-logs.
 	LogDir string
 }
+
+type sessionMode int
+
+const (
+	sessionModeHeadless sessionMode = iota
+	sessionModeNested
+)
 
 // Session is a running headless sway session.
 type Session struct {
@@ -101,6 +108,17 @@ func (m *managedProc) stop(waitTimeout time.Duration) {
 // headless sway, and wl-paste, then waits for the Wayland and sway IPC sockets
 // to appear.
 func StartSession(cfg SessionConfig) (*Session, error) {
+	return startSession(cfg, sessionModeHeadless)
+}
+
+// StartNestedSession creates a new isolated nested sway session. It launches
+// dbus-daemon, nested sway, and wl-paste, then waits for the Wayland and sway
+// IPC sockets to appear.
+func StartNestedSession(cfg SessionConfig) (*Session, error) {
+	return startSession(cfg, sessionModeNested)
+}
+
+func startSession(cfg SessionConfig, mode sessionMode) (*Session, error) {
 	if cfg.Resolution == (image.Point{}) {
 		cfg.Resolution = image.Pt(1024, 768)
 	}
@@ -138,15 +156,22 @@ func StartSession(cfg SessionConfig) (*Session, error) {
 	// 2. Resolve sway config.
 	swayConf := cfg.SwayConfigPath
 	if swayConf == "" {
-		swayConf, err = s.writeEmbeddedConfig(cfg.Resolution)
+		switch mode {
+		case sessionModeHeadless:
+			swayConf, err = s.writeEmbeddedConfig("configs/ci.conf", cfg.Resolution)
+		case sessionModeNested:
+			swayConf, err = s.writeEmbeddedConfig("config/sway/nested.conf", image.Point{})
+		default:
+			err = fmt.Errorf("session: unknown mode %d", mode)
+		}
 		if err != nil {
 			s.Stop()
 			return nil, fmt.Errorf("session: sway config: %w", err)
 		}
 	}
 
-	// 3. Launch headless sway.
-	if err := s.launchSway(swayConf); err != nil {
+	// 3. Launch sway.
+	if err := s.launchSway(swayConf, mode); err != nil {
 		s.Stop()
 		return nil, fmt.Errorf("session: sway: %w", err)
 	}
@@ -281,7 +306,7 @@ func (s *Session) launchDBus() error {
 	return nil
 }
 
-func (s *Session) launchSway(confPath string) error {
+func (s *Session) launchSway(confPath string, mode sessionMode) error {
 	logPath := filepath.Join(s.logDir, "sway-session.log")
 	logFile, err := os.Create(logPath)
 	if err != nil {
@@ -291,13 +316,32 @@ func (s *Session) launchSway(confPath string) error {
 	cmd := executil.CommandContext(context.Background(), "sway", "--unsupported-gpu", "-c", confPath)
 	// Start the compositor with its target runtime variables, but do not pass
 	// SWAYSOCK=. Sway owns this variable and uses it for its IPC socket path.
-	cmd.Env = env.Merge(env.Current().
-		WithSession(s.xdgDir, s.wlDisplay, s.dbusAddr).
-		Without("SWAYSOCK").
-		EnvList(),
-		"WLR_BACKENDS=headless",
-		"WLR_RENDERER=pixman",
-	)
+	runtime := env.Current().
+		With("XDG_RUNTIME_DIR", s.xdgDir).
+		With("DBUS_SESSION_BUS_ADDRESS", s.dbusAddr).
+		Without("SWAYSOCK")
+	switch mode {
+	case sessionModeHeadless:
+		runtime = runtime.Without("WAYLAND_DISPLAY", "DISPLAY")
+		cmd.Env = env.Merge(runtime.EnvList(),
+			"WLR_BACKENDS=headless",
+			"WLR_RENDERER=pixman",
+		)
+	case sessionModeNested:
+		hostSocket := env.Current().SocketPath()
+		if hostSocket == "" {
+			logFile.Close()
+			return fmt.Errorf("nested session requires a host Wayland socket")
+		}
+		runtime = runtime.With("WAYLAND_DISPLAY", hostSocket)
+		cmd.Env = env.Merge(runtime.EnvList(),
+			"WLR_BACKENDS=wayland",
+			"WLR_RENDERER=pixman",
+		)
+	default:
+		logFile.Close()
+		return fmt.Errorf("unknown session mode %d", mode)
+	}
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -372,10 +416,10 @@ func waitForGlob(pattern string, attempts int, interval time.Duration) error {
 	return fmt.Errorf("pattern %s did not match within %s", pattern, time.Duration(attempts)*interval)
 }
 
-// writeEmbeddedConfig writes the embedded ci.conf to the temp dir, patching
-// the resolution to match the requested config.
-func (s *Session) writeEmbeddedConfig(res image.Point) (string, error) {
-	data, err := embeddedConfigs.ReadFile("configs/ci.conf")
+// writeEmbeddedConfig writes an embedded sway config to the temp dir, patching
+// the resolution token when requested.
+func (s *Session) writeEmbeddedConfig(name string, res image.Point) (string, error) {
+	data, err := embeddedConfigs.ReadFile(name)
 	if err != nil {
 		return "", fmt.Errorf("read embedded config: %w", err)
 	}

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   bash scripts/test-integration.sh headless   # Run in a new isolated headless session (default)
-#   bash scripts/test-integration.sh nested     # Run against an existing nested session
+#   bash scripts/test-integration.sh nested     # Start and run a nested session
 #   bash scripts/test-integration.sh desktop    # Run against the host desktop
 #   bash scripts/test-integration.sh --app kwrite headless # Filter by app
 
@@ -29,7 +29,7 @@ case "$MODE" in
         ;;
     nested)
         echo "▶ running integration tests in NESTED mode"
-        # cmd/integration handles auto-discovery of /tmp/perfuncted-xdg-*
+        # cmd/integration starts and owns the nested session
         go run ./cmd/integration --nested "$@"
         ;;
     desktop)


### PR DESCRIPTION
## Summary\n- Make cmd/integration create and tear down its own headless and nested test sessions\n- Stop attaching --nested runs to pre-existing /tmp sessions\n- Keep stale nested-session discovery robust for library callers\n- Add regression coverage for nested session selection and runtime socket-path resolution\n\n## Verification\n- GOCACHE=/tmp/perfuncted-gocache go test ./...