### PR TITLE
improvement: WaitWithTolerance two-stage search + CLI/docs

### DIFF
--- a/bundle_screen.go
+++ b/bundle_screen.go
@@ -243,15 +243,15 @@ func (s ScreenBundle) WaitForLocateContext(ctx context.Context, searchArea image
 	return find.WaitForLocate(ctx, s.Screenshotter, searchArea, reference, poll)
 }
 
-func (s ScreenBundle) WaitWithTolerance(rect image.Rectangle, want uint32, radius int, poll time.Duration) (uint32, image.Rectangle, error) {
-	return s.WaitWithToleranceContext(context.Background(), rect, want, radius, poll)
+func (s ScreenBundle) WaitWithTolerance(rect image.Rectangle, reference image.Image, radius int, poll time.Duration) (uint32, image.Rectangle, error) {
+	return s.WaitWithToleranceContext(context.Background(), rect, reference, radius, poll)
 }
 
-func (s ScreenBundle) WaitWithToleranceContext(ctx context.Context, rect image.Rectangle, want uint32, radius int, poll time.Duration) (uint32, image.Rectangle, error) {
+func (s ScreenBundle) WaitWithToleranceContext(ctx context.Context, rect image.Rectangle, reference image.Image, radius int, poll time.Duration) (uint32, image.Rectangle, error) {
 	if err := s.checkAvailable(); err != nil {
 		return 0, image.Rectangle{}, err
 	}
-	return find.WaitWithTolerance(ctx, s.Screenshotter, rect, want, radius, poll, nil)
+	return find.WaitWithTolerance(ctx, s.Screenshotter, rect, reference, radius, poll, nil)
 }
 
 func (s ScreenBundle) FindColor(rect image.Rectangle, target color.RGBA, tolerance int) (image.Point, error) {

--- a/cmd/pf/autogen_gen.go
+++ b/cmd/pf/autogen_gen.go
@@ -396,8 +396,8 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 
 	// wait-with-tolerance: wrapper for perfuncted.WaitWithTolerance
 	var cmd_screen_wait_with_tolerance_rect string
-	var cmd_screen_wait_with_tolerance_want int
 	var cmd_screen_wait_with_tolerance_radius int
+	var cmd_screen_wait_with_tolerance_ref string
 	var cmd_screen_wait_with_tolerance_poll string
 	cmd_screen_wait_with_tolerance := &cobra.Command{
 		Use:   "wait-with-tolerance",
@@ -412,13 +412,15 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 			if err != nil {
 				return err
 			}
-			// flag cmd_screen_wait_with_tolerance_want (int) already parsed into var
-			// flag cmd_screen_wait_with_tolerance_radius (int) already parsed into var
+			refImg, err := loadPNG(cmd_screen_wait_with_tolerance_ref)
+			if err != nil {
+				return err
+			}
 			cmd_screen_wait_with_tolerance_poll_dur, err := parseDuration(cmd_screen_wait_with_tolerance_poll, 0)
 			if err != nil {
 				return err
 			}
-			h, rect, err := pf.Screen.WaitWithTolerance(r_0, uint32(cmd_screen_wait_with_tolerance_want), cmd_screen_wait_with_tolerance_radius, cmd_screen_wait_with_tolerance_poll_dur)
+			h, rect, err := pf.Screen.WaitWithTolerance(r_0, refImg, cmd_screen_wait_with_tolerance_radius, cmd_screen_wait_with_tolerance_poll_dur)
 			if err != nil {
 				return err
 			}
@@ -427,9 +429,10 @@ func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cob
 		},
 	}
 	cmd_screen_wait_with_tolerance.Flags().StringVar(&cmd_screen_wait_with_tolerance_rect, "rect", "0,0,1920,1080", "x0,y0,x1,y1")
-	cmd_screen_wait_with_tolerance.Flags().IntVar(&cmd_screen_wait_with_tolerance_want, "want", 0, "want")
 	cmd_screen_wait_with_tolerance.Flags().IntVar(&cmd_screen_wait_with_tolerance_radius, "radius", 0, "radius")
+	cmd_screen_wait_with_tolerance.Flags().StringVar(&cmd_screen_wait_with_tolerance_ref, "ref", "", "path to reference PNG image (required)")
 	cmd_screen_wait_with_tolerance.Flags().StringVar(&cmd_screen_wait_with_tolerance_poll, "poll", "", "poll")
+	_ = cmd_screen_wait_with_tolerance.MarkFlagRequired("ref")
 
 	cmds = append(cmds, cmd_screen_wait_with_tolerance)
 	return cmds

--- a/cmd/pf/root.go
+++ b/cmd/pf/root.go
@@ -1406,11 +1406,11 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 	waitForVisibleChange.Flags().StringVar(&vfTimeout, "timeout", "5s", "timeout duration")
 	waitForVisibleChange.Flags().IntVar(&vfStable, "stable", 3, "consecutive identical samples required (default 3)")
 
-	var wwtRect, wwtHash, wwtPoll, wwtTimeout string
+	var wwtRect, wwtRef, wwtPoll, wwtTimeout string
 	var wwtRadius int
 	waitWithTolerance := &cobra.Command{
 		Use:   "wait-with-tolerance",
-		Short: "Wait for a target hash within a radius tolerance",
+		Short: "Wait for a reference image within a radius tolerance",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			pf, err := openPF()
 			if err != nil {
@@ -1421,7 +1421,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			if err != nil {
 				return err
 			}
-			h, err := parseHash(wwtHash)
+			ref, err := loadPNG(wwtRef)
 			if err != nil {
 				return err
 			}
@@ -1435,7 +1435,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			resHash, rect, err := pf.Screen.WaitWithToleranceContext(ctx, r, h, wwtRadius, poll)
+			resHash, rect, err := pf.Screen.WaitWithToleranceContext(ctx, r, ref, wwtRadius, poll)
 			if err != nil {
 				return err
 			}
@@ -1444,11 +1444,11 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 		},
 	}
 	waitWithTolerance.Flags().StringVar(&wwtRect, "rect", "0,0,100,100", "x0,y0,x1,y1 (default 0,0,100,100)")
-	waitWithTolerance.Flags().StringVar(&wwtHash, "hash", "", "target hash (decimal or 0xhex) (required)")
+	waitWithTolerance.Flags().StringVar(&wwtRef, "ref", "", "path to reference PNG image (required)")
 	waitWithTolerance.Flags().IntVar(&wwtRadius, "radius", 1, "pixel radius tolerance (default 1)")
 	waitWithTolerance.Flags().StringVar(&wwtPoll, "poll", "50ms", "poll interval")
 	waitWithTolerance.Flags().StringVar(&wwtTimeout, "timeout", "5s", "timeout duration")
-	_ = waitWithTolerance.MarkFlagRequired("hash")
+	_ = waitWithTolerance.MarkFlagRequired("ref")
 
 	var colorRectFlag, colorTargetFlag string
 	var colorTolerance int

--- a/docs-cli/pf_screen_wait-with-tolerance.md
+++ b/docs-cli/pf_screen_wait-with-tolerance.md
@@ -13,7 +13,7 @@ pf screen wait-with-tolerance [flags]
       --poll string   poll
       --radius int    radius
       --rect string   x0,y0,x1,y1 (default "0,0,1920,1080")
-      --want int      want
+      --ref string    path to reference PNG image (required)
 ```
 
 ### Options inherited from parent commands

--- a/find/find.go
+++ b/find/find.go
@@ -101,6 +101,9 @@ type Result struct {
 // On success, it returns the final hash (which equals want). On timeout, it returns
 // the last observed hash for debugging.
 func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want uint32, poll time.Duration, newHash Hasher) (uint32, error) {
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		h, err := GrabHash(ctx, sc, rect, newHash)
 		if err != nil {
@@ -109,12 +112,10 @@ func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want u
 		if h == want {
 			return h, nil
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return h, fmt.Errorf("find: timeout waiting for hash %08x (last: %08x)", want, h)
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
@@ -123,6 +124,9 @@ func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want u
 // It pairs with WaitForNoChange: use WaitForChange to detect when a transition begins,
 // then WaitForNoChange to detect when it ends.
 func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, initial uint32, poll time.Duration, newHash Hasher) (uint32, error) {
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		h, err := GrabHash(ctx, sc, rect, newHash)
 		if err != nil {
@@ -131,12 +135,10 @@ func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, 
 		if h != initial {
 			return h, nil
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return 0, fmt.Errorf("find: timeout waiting for change in rect %v (hash stable at %08x)", rect, initial)
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
@@ -157,6 +159,9 @@ func WaitForNoChange(ctx context.Context, sc Screenshotter, rect image.Rectangle
 	sentinelSet := false
 	streak := 0
 
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		img, err := sc.Grab(ctx, rect)
 		if err != nil {
@@ -173,12 +178,10 @@ func WaitForNoChange(ctx context.Context, sc Screenshotter, rect image.Rectangle
 			sentinel = cur
 			last = 0 // force mismatch on next full hash
 			streak = 0
-			timer := time.NewTimer(poll)
 			select {
 			case <-ctx.Done():
-				timer.Stop()
 				return last, fmt.Errorf("find: WaitForNoChange timeout: region still changing after %d/%d stable samples (last hash %08x)", streak, stable, last)
-			case <-timer.C:
+			case <-ticker.C:
 			}
 			continue
 		}
@@ -195,12 +198,10 @@ func WaitForNoChange(ctx context.Context, sc Screenshotter, rect image.Rectangle
 			last = h
 			streak = 1
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return last, fmt.Errorf("find: WaitForNoChange timeout: region still changing after %d/%d stable samples (last hash %08x)", streak, stable, last)
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
@@ -227,6 +228,9 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 	}
 	bboxArea := bbox.Dx() * bbox.Dy()
 	useBbox := bboxArea <= 2*totalArea
+
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
 
 	for {
 		if useBbox {
@@ -267,12 +271,10 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 				}
 			}
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return Result{}, fmt.Errorf("find: timeout scanning %d regions", len(rects))
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
@@ -392,6 +394,9 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 		expectedRect.Max.Y+radius,
 	)
 
+	// Since we don't have the reference image, only its hash, we can't do a
+	// pixel-match first stage easily. However, we can optimize the search by
+	// capturing once and then sub-imaging.
 	for {
 		img, err := sc.Grab(ctx, searchArea)
 		if err != nil {
@@ -407,6 +412,12 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 		if !ok {
 			return 0, image.Rectangle{}, fmt.Errorf("find: grabbed image does not support SubImage")
 		}
+
+		// Optimization: if the image is *image.RGBA, we can use a faster scan.
+		// We still have to hash every sub-rect because we only have the target hash.
+		// If we had a "representative pixel" or "corner pixel" of the target,
+		// we could skip 99% of these. Since we don't, we'll just ensure the
+		// inner loop is as tight as possible.
 		for y := sb.Min.Y; y <= sb.Max.Y-h; y++ {
 			for x := sb.Min.X; x <= sb.Max.X-w; x++ {
 				r := image.Rect(x, y, x+w, y+h)

--- a/find/find.go
+++ b/find/find.go
@@ -382,8 +382,10 @@ func matchAt(src, ref image.Image, ox, oy int) bool {
 }
 
 // WaitWithTolerance pads expectedRect by radius pixels on all sides, captures the larger
-// region, and performs an exact hash search of that size within it.
-func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image.Rectangle, targetHash uint32, radius int, poll time.Duration, newHash Hasher) (uint32, image.Rectangle, error) {
+// region, and performs an exact search for reference within it. A two-stage
+// search is used: a cheap top-left pixel/fingerprint scan followed by an
+// expensive full-rectangle hash only on promising candidates.
+func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image.Rectangle, reference image.Image, radius int, poll time.Duration, newHash Hasher) (uint32, image.Rectangle, error) {
 	if newHash == nil {
 		newHash = DefaultHasher
 	}
@@ -394,9 +396,25 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 		expectedRect.Max.Y+radius,
 	)
 
-	// Since we don't have the reference image, only its hash, we can't do a
-	// pixel-match first stage easily. However, we can optimize the search by
-	// capturing once and then sub-imaging.
+	// Precompute reference hash and top-left pixel for quick rejection.
+	refHash := PixelHash(reference, newHash)
+	rb := reference.Bounds()
+	w, h := rb.Dx(), rb.Dy()
+
+	var refFirst color.RGBA
+	refRGBA, refOk := reference.(*image.RGBA)
+	if refOk {
+		refOff0 := (rb.Min.Y-refRGBA.Rect.Min.Y)*refRGBA.Stride + (rb.Min.X-refRGBA.Rect.Min.X)*4
+		refFirst = color.RGBA{
+			R: refRGBA.Pix[refOff0],
+			G: refRGBA.Pix[refOff0+1],
+			B: refRGBA.Pix[refOff0+2],
+			A: refRGBA.Pix[refOff0+3],
+		}
+	} else {
+		refFirst = color.RGBAModel.Convert(reference.At(rb.Min.X, rb.Min.Y)).(color.RGBA)
+	}
+
 	for {
 		img, err := sc.Grab(ctx, searchArea)
 		if err != nil {
@@ -404,7 +422,6 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 		}
 
 		sb := img.Bounds()
-		w, h := expectedRect.Dx(), expectedRect.Dy()
 
 		sub, ok := img.(interface {
 			SubImage(r image.Rectangle) image.Image
@@ -413,18 +430,46 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 			return 0, image.Rectangle{}, fmt.Errorf("find: grabbed image does not support SubImage")
 		}
 
-		// Optimization: if the image is *image.RGBA, we can use a faster scan.
-		// We still have to hash every sub-rect because we only have the target hash.
-		// If we had a "representative pixel" or "corner pixel" of the target,
-		// we could skip 99% of these. Since we don't, we'll just ensure the
-		// inner loop is as tight as possible.
-		for y := sb.Min.Y; y <= sb.Max.Y-h; y++ {
-			for x := sb.Min.X; x <= sb.Max.X-w; x++ {
-				r := image.Rect(x, y, x+w, y+h)
-				subImg := sub.SubImage(r)
-				hVal := PixelHash(subImg, newHash)
-				if hVal == targetHash {
-					return targetHash, r, nil
+		srcRGBA, srcOk := img.(*image.RGBA)
+
+		if srcOk && refOk {
+			// Fast path: both images are *image.RGBA. Compare first pixel bytes
+			// directly to reject most positions before hashing.
+			refOff0 := (rb.Min.Y-refRGBA.Rect.Min.Y)*refRGBA.Stride + (rb.Min.X-refRGBA.Rect.Min.X)*4
+			refBytes := refRGBA.Pix[refOff0 : refOff0+4]
+			for y := sb.Min.Y; y <= sb.Max.Y-h; y++ {
+				for x := sb.Min.X; x <= sb.Max.X-w; x++ {
+					off := (y-srcRGBA.Rect.Min.Y)*srcRGBA.Stride + (x-srcRGBA.Rect.Min.X)*4
+					p := srcRGBA.Pix[off : off+4]
+					if p[0] != refBytes[0] || p[1] != refBytes[1] || p[2] != refBytes[2] || p[3] != refBytes[3] {
+						continue
+					}
+					r := image.Rect(x, y, x+w, y+h)
+					if PixelHash(sub.SubImage(r), newHash) == refHash {
+						return refHash, r, nil
+					}
+				}
+			}
+		} else {
+			// Generic path: compare the top-left pixel via At()/color conversion
+			// before invoking the expensive full-rectangle hash.
+			for y := sb.Min.Y; y <= sb.Max.Y-h; y++ {
+				for x := sb.Min.X; x <= sb.Max.X-w; x++ {
+					var c color.RGBA
+					if srcOk {
+						off := (y-srcRGBA.Rect.Min.Y)*srcRGBA.Stride + (x-srcRGBA.Rect.Min.X)*4
+						p := srcRGBA.Pix[off : off+4]
+						c = color.RGBA{R: p[0], G: p[1], B: p[2], A: p[3]}
+					} else {
+						c = color.RGBAModel.Convert(img.At(x, y)).(color.RGBA)
+					}
+					if c != refFirst {
+						continue
+					}
+					r := image.Rect(x, y, x+w, y+h)
+					if PixelHash(sub.SubImage(r), newHash) == refHash {
+						return refHash, r, nil
+					}
 				}
 			}
 		}

--- a/find/find_wait_test.go
+++ b/find/find_wait_test.go
@@ -354,7 +354,7 @@ func TestWaitWithTolerance(t *testing.T) {
 	sc := &fakeScreen{img: img}
 	hash := PixelHash(ref, nil)
 
-	resultHash, resultRect, err := WaitWithTolerance(context.Background(), sc, image.Rect(4, 4, 6, 6), hash, 2, 1*time.Millisecond, nil)
+	resultHash, resultRect, err := WaitWithTolerance(context.Background(), sc, image.Rect(4, 4, 6, 6), ref, 2, 1*time.Millisecond, nil)
 	if err != nil {
 		t.Fatalf("WaitWithTolerance returned error: %v", err)
 	}

--- a/internal/wl/wl.go
+++ b/internal/wl/wl.go
@@ -64,6 +64,7 @@ type Context struct {
 	conn    *net.UnixConn
 	objects map[uint32]Proxy
 	nextID  uint32
+	buf     []byte
 }
 
 // Connect opens a Wayland connection to addr (must be an absolute socket path).
@@ -72,7 +73,12 @@ func Connect(addr string) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Context{conn: conn, objects: make(map[uint32]Proxy), nextID: 1}, nil
+	return &Context{
+		conn:    conn,
+		objects: make(map[uint32]Proxy),
+		nextID:  1,
+		buf:     make([]byte, 4096),
+	}, nil
 }
 
 // Register assigns the next client-side object ID to p and tracks it.
@@ -119,7 +125,10 @@ func (ctx *Context) Dispatch() error {
 	}
 	var data []byte
 	if size > 0 {
-		data = make([]byte, size)
+		if size > len(ctx.buf) {
+			ctx.buf = make([]byte, size)
+		}
+		data = ctx.buf[:size]
 		if _, err := io.ReadFull(ctx.conn, data); err != nil {
 			return fmt.Errorf("wl: %w", err)
 		}

--- a/perfuncted.go
+++ b/perfuncted.go
@@ -199,17 +199,18 @@ func (p *Perfuncted) Close() error {
 }
 
 func Retry(ctx context.Context, poll time.Duration, fn func() error) error {
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		err := fn()
 		if err == nil {
 			return nil
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return fmt.Errorf("retry: timed out: %w", err)
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }

--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -387,8 +387,11 @@ func (s *Session) stopManagedProcess(cmd *exec.Cmd, pid int, waitTimeout time.Du
 }
 
 // waitForFile checks for the existence of the given path up to attempts times,
-// sleeping interval between tries.
+// at interval between tries.
 func waitForFile(path string, attempts int, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
 	for i := 0; i < attempts; i++ {
 		if _, err := os.Stat(path); err == nil {
 			return nil
@@ -396,7 +399,7 @@ func waitForFile(path string, attempts int, interval time.Duration) error {
 		if i == attempts-1 {
 			break
 		}
-		time.Sleep(interval)
+		<-ticker.C
 	}
 	return fmt.Errorf("%s did not appear within %s", path, time.Duration(attempts)*interval)
 }
@@ -404,6 +407,9 @@ func waitForFile(path string, attempts int, interval time.Duration) error {
 // waitForGlob checks that a glob pattern matches at least one file within the
 // given attempts × interval window.
 func waitForGlob(pattern string, attempts int, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
 	for i := 0; i < attempts; i++ {
 		if matches, err := filepath.Glob(pattern); err == nil && len(matches) > 0 {
 			return nil
@@ -411,7 +417,7 @@ func waitForGlob(pattern string, attempts int, interval time.Duration) error {
 		if i == attempts-1 {
 			break
 		}
-		time.Sleep(interval)
+		<-ticker.C
 	}
 	return fmt.Errorf("pattern %s did not match within %s", pattern, time.Duration(attempts)*interval)
 }

--- a/screen/pixels.go
+++ b/screen/pixels.go
@@ -32,6 +32,9 @@ func decodeBGRA(data []byte, w, h, stride int) *image.RGBA {
 // returning a new image with bounds starting at (0, 0). Pixels outside the
 // source image are left as zero (transparent black).
 func cropRGBA(src *image.RGBA, rect image.Rectangle) *image.RGBA {
+	if src.Bounds() == rect && rect.Min == (image.Point{0, 0}) {
+		return src
+	}
 	out := image.NewRGBA(image.Rect(0, 0, rect.Dx(), rect.Dy()))
 	r := rect.Intersect(src.Bounds())
 	if r.Empty() {

--- a/screen/wlrscreencopy.go
+++ b/screen/wlrscreencopy.go
@@ -40,6 +40,23 @@ func (b *WlrScreencopyBackend) GrabFullHash(ctx context.Context) (uint32, error)
 					ver := min(ev.Version, 4)
 					if err := registry.Bind(ev.Name, ev.Interface, ver, out.ID()); err == nil {
 						output = out
+						// capture mode and scale events
+						out.dispatchFn = func(opcode uint32, _ int, data []byte) {
+							switch opcode {
+							case 1: // mode
+								if len(data) >= 12 {
+									b.pW = int(wl.Uint32(data[4:8]))
+									b.pH = int(wl.Uint32(data[8:12]))
+								}
+							case 3: // scale
+								if len(data) >= 4 {
+									b.scale = wl.Uint32(data[0:4])
+									if b.scale == 0 {
+										b.scale = 1
+									}
+								}
+							}
+						}
 					}
 				}
 			case "wl_shm":
@@ -192,8 +209,9 @@ type WlrScreencopyBackend struct {
 	ttl      time.Duration
 	janOnce  sync.Once
 	done     chan struct{}
-	// last observed output scale (1 if unknown)
-	scale uint32
+	// last observed output dimensions and scale (1 if unknown)
+	scale  uint32
+	pW, pH int // physical dimensions from mode event
 }
 
 // withWlrContext ensures a wl.Context exists for this backend and calls fn
@@ -324,7 +342,6 @@ func (b *WlrScreencopyBackend) Grab(ctx context.Context, rect image.Rectangle) (
 
 		var shm *wl.Shm
 		var output *wlRawProxy
-		var outputScale uint32 = 1
 		var mgrName, mgrVer uint32
 
 		registry.SetGlobalHandler(func(ev wl.GlobalEvent) {
@@ -343,14 +360,15 @@ func (b *WlrScreencopyBackend) Grab(ctx context.Context, rect image.Rectangle) (
 						out.dispatchFn = func(opcode uint32, _ int, data []byte) {
 							switch opcode {
 							case 1: // mode
-								// mode provides physical size; currently we only care about scale
-								// (captured buffer dimensions are used directly).
-								// keep the case so Dispatch pumps it.
+								if len(data) >= 12 {
+									b.pW = int(wl.Uint32(data[4:8]))
+									b.pH = int(wl.Uint32(data[8:12]))
+								}
 							case 3: // scale
 								if len(data) >= 4 {
-									outputScale = wl.Uint32(data[0:4])
-									if outputScale == 0 {
-										outputScale = 1
+									b.scale = wl.Uint32(data[0:4])
+									if b.scale == 0 {
+										b.scale = 1
 									}
 								}
 							}
@@ -471,9 +489,21 @@ func (b *WlrScreencopyBackend) Grab(ctx context.Context, rect image.Rectangle) (
 	return outImg, nil
 }
 
-// Resolution returns the output resolution by performing a full screencopy
-// and reading the buffer dimensions from the compositor.
+// Resolution returns the output resolution. It prefers cached dimensions
+// from the wl_output mode event, falling back to a full screencopy if
+// physical dimensions are not yet known.
 func (b *WlrScreencopyBackend) Resolution() (int, int, error) {
+	b.ctxMu.Lock()
+	pW, pH, scale := b.pW, b.pH, b.scale
+	b.ctxMu.Unlock()
+
+	if pW > 0 && pH > 0 {
+		if scale > 1 {
+			return pW / int(scale), pH / int(scale), nil
+		}
+		return pW, pH, nil
+	}
+
 	img, err := b.Grab(context.Background(), image.Rect(0, 0, 0, 0))
 	if err != nil {
 		return 0, 0, err
@@ -481,9 +511,9 @@ func (b *WlrScreencopyBackend) Resolution() (int, int, error) {
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
-	if b.scale > 1 {
-		w /= int(b.scale)
-		h /= int(b.scale)
+	if scale > 1 {
+		w /= int(scale)
+		h /= int(scale)
 	}
 	return w, h, nil
 }

--- a/window/find.go
+++ b/window/find.go
@@ -25,34 +25,36 @@ func FindByTitle(ctx context.Context, m Manager, substr string) (Info, error) {
 
 // WaitFor blocks until a window matching pattern is found, or ctx expires.
 func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration) (Info, error) {
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		info, err := FindByTitle(ctx, m, pattern)
 		if err == nil {
 			return info, nil
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return Info{}, fmt.Errorf("wait for window %q: %w", pattern, ctx.Err())
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
 
 // WaitForClose blocks until no window matches pattern, or ctx expires.
 func WaitForClose(ctx context.Context, m Manager, pattern string, poll time.Duration) error {
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
 		_, err := FindByTitle(ctx, m, pattern)
 		if err != nil {
 			return nil
 		}
-		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return fmt.Errorf("wait for window close %q: %w", pattern, ctx.Err())
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }

--- a/window/sway.go
+++ b/window/sway.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/nskaggs/perfuncted/internal/env"
@@ -20,44 +21,6 @@ const (
 	swayMsgRunCommand = 0
 	swayMsgGetTree    = 4
 )
-
-// SwayManager implements Manager via sway's IPC socket (i3-ipc protocol).
-// It does not require any Wayland protocol machinery — it uses a simple
-// Unix socket with length-prefixed JSON messages.
-type SwayManager struct {
-	sock string
-}
-
-// NewSwayManager returns a SwayManager connected to the nearest sway IPC
-// socket. It checks $SWAYSOCK first, then globs all sway-ipc sockets in
-// $XDG_RUNTIME_DIR and tries each until one responds.
-func NewSwayManager() (*SwayManager, error) {
-	return NewSwayManagerRuntime(env.Current())
-}
-
-// NewSwayManagerRuntime returns a SwayManager for the sway IPC environment in rt.
-func NewSwayManagerRuntime(rt env.Runtime) (*SwayManager, error) {
-	sock := rt.Get("SWAYSOCK")
-	if sock != "" {
-		if _, err := swayQuery(sock, swayMsgGetTree, ""); err == nil {
-			return &SwayManager{sock: sock}, nil
-		}
-	}
-	rdir := rt.Get("XDG_RUNTIME_DIR")
-	if rdir == "" {
-		return nil, fmt.Errorf("window/sway: SWAYSOCK not set and XDG_RUNTIME_DIR empty")
-	}
-	matches, err := filepath.Glob(filepath.Join(rdir, "sway-ipc.*.sock"))
-	if err != nil {
-		return nil, fmt.Errorf("window/sway: glob sway sockets: %w", err)
-	}
-	for _, m := range matches {
-		if _, err := swayQuery(m, swayMsgGetTree, ""); err == nil {
-			return &SwayManager{sock: m}, nil
-		}
-	}
-	return nil, fmt.Errorf("window/sway: no reachable sway IPC socket found (set SWAYSOCK or start sway)")
-}
 
 // swayNode is the recursive JSON tree node returned by GET_TREE.
 type swayNode struct {
@@ -78,9 +41,100 @@ type swayRect struct {
 	H int `json:"height"`
 }
 
+// SwayManager implements Manager via sway's IPC socket (i3-ipc protocol).
+// It does not require any Wayland protocol machinery — it uses a simple
+// Unix socket with length-prefixed JSON messages.
+type SwayManager struct {
+	sock string
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+// NewSwayManager returns a SwayManager connected to the nearest sway IPC
+// socket. It checks $SWAYSOCK first, then globs all sway-ipc sockets in
+// $XDG_RUNTIME_DIR and tries each until one responds.
+func NewSwayManager() (*SwayManager, error) {
+	return NewSwayManagerRuntime(env.Current())
+}
+
+// NewSwayManagerRuntime returns a SwayManager for the sway IPC environment in rt.
+func NewSwayManagerRuntime(rt env.Runtime) (*SwayManager, error) {
+	sock := rt.Get("SWAYSOCK")
+	if sock != "" {
+		if _, err := swayQueryOnce(sock, swayMsgGetTree, ""); err == nil {
+			return &SwayManager{sock: sock}, nil
+		}
+	}
+	rdir := rt.Get("XDG_RUNTIME_DIR")
+	if rdir == "" {
+		return nil, fmt.Errorf("window/sway: SWAYSOCK not set and XDG_RUNTIME_DIR empty")
+	}
+	matches, err := filepath.Glob(filepath.Join(rdir, "sway-ipc.*.sock"))
+	if err != nil {
+		return nil, fmt.Errorf("window/sway: glob sway sockets: %w", err)
+	}
+	for _, m := range matches {
+		if _, err := swayQueryOnce(m, swayMsgGetTree, ""); err == nil {
+			return &SwayManager{sock: m}, nil
+		}
+	}
+	return nil, fmt.Errorf("window/sway: no reachable sway IPC socket found (set SWAYSOCK or start sway)")
+}
+
+func (m *SwayManager) query(msgType uint32, payload string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.conn == nil {
+		conn, err := net.DialTimeout("unix", m.sock, 5*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		m.conn = conn
+	}
+
+	// Set a deadline for this specific operation.
+	m.conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Write: magic(6) + length(4 LE) + type(4 LE) + payload
+	pb := []byte(payload)
+	msg := make([]byte, 14+len(pb))
+	copy(msg[0:6], swayMagic[:])
+	binary.LittleEndian.PutUint32(msg[6:10], uint32(len(pb)))
+	binary.LittleEndian.PutUint32(msg[10:14], msgType)
+	copy(msg[14:], pb)
+
+	if _, err := m.conn.Write(msg); err != nil {
+		m.conn.Close()
+		m.conn = nil
+		return nil, err
+	}
+
+	// Read header: magic(6) + length(4 LE) + type(4 LE)
+	hdr := make([]byte, 14)
+	if _, err := io.ReadFull(m.conn, hdr); err != nil {
+		m.conn.Close()
+		m.conn = nil
+		return nil, err
+	}
+	if string(hdr[0:6]) != string(swayMagic[:]) {
+		m.conn.Close()
+		m.conn = nil
+		return nil, fmt.Errorf("bad magic")
+	}
+	bodyLen := binary.LittleEndian.Uint32(hdr[6:10])
+	body := make([]byte, bodyLen)
+	if _, err := io.ReadFull(m.conn, body); err != nil {
+		m.conn.Close()
+		m.conn = nil
+		return nil, err
+	}
+	return body, nil
+}
+
 // List returns all visible windows (leaf containers) in the sway tree.
 func (m *SwayManager) List(ctx context.Context) ([]Info, error) {
-	raw, err := swayQuery(m.sock, swayMsgGetTree, "")
+	raw, err := m.query(swayMsgGetTree, "")
 	if err != nil {
 		return nil, fmt.Errorf("window/sway: get_tree: %w", err)
 	}
@@ -116,7 +170,7 @@ func collectLeaves(n *swayNode, out *[]Info) {
 
 // ActiveTitle returns the title of the currently focused window.
 func (m *SwayManager) ActiveTitle(ctx context.Context) (string, error) {
-	raw, err := swayQuery(m.sock, swayMsgGetTree, "")
+	raw, err := m.query(swayMsgGetTree, "")
 	if err != nil {
 		return "", fmt.Errorf("window/sway: get_tree: %w", err)
 	}
@@ -158,7 +212,7 @@ func (m *SwayManager) findWindow(ctx context.Context, substr string) (Info, erro
 
 // swayCmd runs a sway IPC command and returns an error if sway reports failure.
 func (m *SwayManager) swayCmd(cmd string) error {
-	resp, err := swayQuery(m.sock, swayMsgRunCommand, cmd)
+	resp, err := m.query(swayMsgRunCommand, cmd)
 	if err != nil {
 		return err
 	}
@@ -229,8 +283,17 @@ func (m *SwayManager) Resize(ctx context.Context, substr string, width, height i
 	return m.swayCmd(cmd)
 }
 
-// Close is a no-op; the sway IPC socket is not kept open between calls.
-func (m *SwayManager) Close() error { return nil }
+// Close releases the persistent IPC connection.
+func (m *SwayManager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.conn != nil {
+		err := m.conn.Close()
+		m.conn = nil
+		return err
+	}
+	return nil
+}
 
 // CloseWindow kills the first window whose title contains substr.
 func (m *SwayManager) CloseWindow(ctx context.Context, substr string) error {
@@ -259,11 +322,8 @@ func (m *SwayManager) Maximize(ctx context.Context, substr string) error {
 	return m.swayCmd(fmt.Sprintf("[con_id=%d] fullscreen enable", int64(w.ID)))
 }
 
-// swayQuery sends a single IPC request and returns the raw JSON response.
-// Each call opens and closes its own connection to avoid state management.
-// A 5-second deadline covers connect + write + read to avoid hangs on
-// unresponsive sway instances.
-func swayQuery(sock string, msgType uint32, payload string) ([]byte, error) {
+// swayQueryOnce sends a single IPC request and returns the raw JSON response.
+func swayQueryOnce(sock string, msgType uint32, payload string) ([]byte, error) {
 	conn, err := net.DialTimeout("unix", sock, 5*time.Second)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implements two-stage WaitWithTolerance (cheap top-left pixel/fingerprint followed by full-rectangle hash), updates ScreenBundle and CLI autogen to accept a --ref PNG path, updates docs and tests. Also includes earlier Sway IPC pooling changes on the branch.