### PR TITLE
Make X11 testable

### DIFF
--- a/internal/x11/connection.go
+++ b/internal/x11/connection.go
@@ -1,0 +1,102 @@
+package x11
+
+import (
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/composite"
+	"github.com/jezek/xgb/xproto"
+)
+
+type Connection interface {
+	Close()
+	DefaultScreen() *xproto.ScreenInfo
+	InternAtom(OnlyIfExists bool, NameLen uint16, Name string) InternAtomCookie
+	GetProperty(Delete bool, Window xproto.Window, Property, Type xproto.Atom, LongOffset, LongLength uint32) GetPropertyCookie
+	GetGeometry(Drawable xproto.Drawable) GetGeometryCookie
+	TranslateCoordinates(SrcWindow, DstWindow xproto.Window, SrcX, SrcY int16) TranslateCoordinatesCookie
+	SendEventChecked(Propagate bool, Destination xproto.Window, EventMask uint32, Event string) SendEventCookie
+	MapWindowChecked(Window xproto.Window) MapWindowCookie
+	ConfigureWindowChecked(Window xproto.Window, ValueMask uint16, ValueList []uint32) ConfigureWindowCookie
+	NewId() (uint32, error)
+	GetImage(Format byte, Drawable xproto.Drawable, X, Y int16, Width, Height uint16, PlaneMask uint32) GetImageCookie
+	FreePixmap(Pixmap xproto.Pixmap) FreePixmapCookie
+	InitComposite() error
+	NameWindowPixmap(Window xproto.Window, Pixmap xproto.Pixmap) NameWindowPixmapCookie
+}
+
+type XgbConnection struct {
+	conn *xgb.Conn
+}
+
+func NewXgbConnection(displayName string) (*XgbConnection, error) {
+	conn, err := xgb.NewConnDisplay(displayName)
+	if err != nil {
+		return nil, err
+	}
+	return &XgbConnection{conn: conn}, nil
+}
+
+func (c *XgbConnection) Close() {
+	c.conn.Close()
+}
+
+func (c *XgbConnection) DefaultScreen() *xproto.ScreenInfo {
+	return xproto.Setup(c.conn).DefaultScreen(c.conn)
+}
+
+func (c *XgbConnection) InternAtom(OnlyIfExists bool, NameLen uint16, Name string) InternAtomCookie {
+	cookie := xproto.InternAtom(c.conn, OnlyIfExists, NameLen, Name)
+	return NewXProtoInternAtomCookie(cookie)
+}
+
+func (c *XgbConnection) GetProperty(Delete bool, Window xproto.Window, Property, Type xproto.Atom, LongOffset, LongLength uint32) GetPropertyCookie {
+	cookie := xproto.GetProperty(c.conn, Delete, Window, Property, Type, LongOffset, LongLength)
+	return NewXProtoGetPropertyCookie(cookie)
+}
+
+func (c *XgbConnection) GetGeometry(Drawable xproto.Drawable) GetGeometryCookie {
+	cookie := xproto.GetGeometry(c.conn, Drawable)
+	return NewXProtoGetGeometryCookie(cookie)
+}
+
+func (c *XgbConnection) TranslateCoordinates(SrcWindow, DstWindow xproto.Window, SrcX, SrcY int16) TranslateCoordinatesCookie {
+	cookie := xproto.TranslateCoordinates(c.conn, SrcWindow, DstWindow, SrcX, SrcY)
+	return NewXProtoTranslateCoordinatesCookie(cookie)
+}
+
+func (c *XgbConnection) SendEventChecked(Propagate bool, Destination xproto.Window, EventMask uint32, Event string) SendEventCookie {
+	cookie := xproto.SendEventChecked(c.conn, Propagate, Destination, EventMask, Event)
+	return NewXProtoSendEventCookie(cookie)
+}
+
+func (c *XgbConnection) MapWindowChecked(Window xproto.Window) MapWindowCookie {
+	cookie := xproto.MapWindowChecked(c.conn, Window)
+	return NewXProtoMapWindowCookie(cookie)
+}
+
+func (c *XgbConnection) ConfigureWindowChecked(Window xproto.Window, ValueMask uint16, ValueList []uint32) ConfigureWindowCookie {
+	cookie := xproto.ConfigureWindowChecked(c.conn, Window, ValueMask, ValueList)
+	return NewXProtoConfigureWindowCookie(cookie)
+}
+
+func (c *XgbConnection) NewId() (uint32, error) {
+	return c.conn.NewId()
+}
+
+func (c *XgbConnection) GetImage(Format byte, Drawable xproto.Drawable, X, Y int16, Width, Height uint16, PlaneMask uint32) GetImageCookie {
+	cookie := xproto.GetImage(c.conn, Format, Drawable, X, Y, Width, Height, PlaneMask)
+	return NewXProtoGetImageCookie(cookie)
+}
+
+func (c *XgbConnection) FreePixmap(Pixmap xproto.Pixmap) FreePixmapCookie {
+	cookie := xproto.FreePixmap(c.conn, Pixmap)
+	return NewXProtoFreePixmapCookie(cookie)
+}
+
+func (c *XgbConnection) InitComposite() error {
+	return composite.Init(c.conn)
+}
+
+func (c *XgbConnection) NameWindowPixmap(Window xproto.Window, Pixmap xproto.Pixmap) NameWindowPixmapCookie {
+	cookie := composite.NameWindowPixmap(c.conn, Window, Pixmap)
+	return NewXProtoNameWindowPixmapCookie(cookie)
+}

--- a/internal/x11/cookies.go
+++ b/internal/x11/cookies.go
@@ -1,0 +1,173 @@
+package x11
+
+import (
+	"github.com/jezek/xgb/composite"
+	"github.com/jezek/xgb/xproto"
+)
+
+type InternAtomCookie interface {
+	Reply() (*xproto.InternAtomReply, error)
+}
+
+type GetPropertyCookie interface {
+	Reply() (*xproto.GetPropertyReply, error)
+}
+
+type GetGeometryCookie interface {
+	Reply() (*xproto.GetGeometryReply, error)
+}
+
+type TranslateCoordinatesCookie interface {
+	Reply() (*xproto.TranslateCoordinatesReply, error)
+}
+
+type SendEventCookie interface {
+	Check() error
+}
+
+type MapWindowCookie interface {
+	Check() error
+}
+
+type ConfigureWindowCookie interface {
+	Check() error
+}
+
+type GetImageCookie interface {
+	Reply() (*xproto.GetImageReply, error)
+}
+
+type FreePixmapCookie interface {
+	Check() error
+}
+
+type NameWindowPixmapCookie interface {
+	Check() error
+}
+
+// XProtoInternAtomCookie encapsulates xproto.InternAtomCookie
+type XProtoInternAtomCookie struct {
+	cookie xproto.InternAtomCookie
+}
+
+func NewXProtoInternAtomCookie(c xproto.InternAtomCookie) *XProtoInternAtomCookie {
+	return &XProtoInternAtomCookie{cookie: c}
+}
+
+func (c *XProtoInternAtomCookie) Reply() (*xproto.InternAtomReply, error) {
+	return c.cookie.Reply()
+}
+
+// XProtoGetPropertyCookie encapsulates xproto.GetPropertyCookie
+type XProtoGetPropertyCookie struct {
+	cookie xproto.GetPropertyCookie
+}
+
+func NewXProtoGetPropertyCookie(c xproto.GetPropertyCookie) *XProtoGetPropertyCookie {
+	return &XProtoGetPropertyCookie{cookie: c}
+}
+
+func (c *XProtoGetPropertyCookie) Reply() (*xproto.GetPropertyReply, error) {
+	return c.cookie.Reply()
+}
+
+// XProtoGetGeometryCookie encapsulates xproto.GetGeometryCookie
+type XProtoGetGeometryCookie struct {
+	cookie xproto.GetGeometryCookie
+}
+
+func NewXProtoGetGeometryCookie(c xproto.GetGeometryCookie) *XProtoGetGeometryCookie {
+	return &XProtoGetGeometryCookie{cookie: c}
+}
+
+func (c *XProtoGetGeometryCookie) Reply() (*xproto.GetGeometryReply, error) {
+	return c.cookie.Reply()
+}
+
+// XProtoTranslateCoordinatesCookie encapsulates xproto.TranslateCoordinatesCookie
+type XProtoTranslateCoordinatesCookie struct {
+	cookie xproto.TranslateCoordinatesCookie
+}
+
+func NewXProtoTranslateCoordinatesCookie(c xproto.TranslateCoordinatesCookie) *XProtoTranslateCoordinatesCookie {
+	return &XProtoTranslateCoordinatesCookie{cookie: c}
+}
+
+func (c *XProtoTranslateCoordinatesCookie) Reply() (*xproto.TranslateCoordinatesReply, error) {
+	return c.cookie.Reply()
+}
+
+// XProtoSendEventCookie encapsulates xproto.SendEventCookie
+type XProtoSendEventCookie struct {
+	cookie xproto.SendEventCookie
+}
+
+func NewXProtoSendEventCookie(c xproto.SendEventCookie) *XProtoSendEventCookie {
+	return &XProtoSendEventCookie{cookie: c}
+}
+
+func (c *XProtoSendEventCookie) Check() error {
+	return c.cookie.Check()
+}
+
+// XProtoMapWindowCookie encapsulates xproto.MapWindowCookie
+type XProtoMapWindowCookie struct {
+	cookie xproto.MapWindowCookie
+}
+
+func NewXProtoMapWindowCookie(c xproto.MapWindowCookie) *XProtoMapWindowCookie {
+	return &XProtoMapWindowCookie{cookie: c}
+}
+
+func (c *XProtoMapWindowCookie) Check() error {
+	return c.cookie.Check()
+}
+
+// XProtoConfigureWindowCookie encapsulates xproto.ConfigureWindowCookie
+type XProtoConfigureWindowCookie struct {
+	cookie xproto.ConfigureWindowCookie
+}
+
+func NewXProtoConfigureWindowCookie(c xproto.ConfigureWindowCookie) *XProtoConfigureWindowCookie {
+	return &XProtoConfigureWindowCookie{cookie: c}
+}
+
+func (c *XProtoConfigureWindowCookie) Check() error {
+	return c.cookie.Check()
+}
+
+type XProtoGetImageCookie struct {
+	cookie xproto.GetImageCookie
+}
+
+func NewXProtoGetImageCookie(c xproto.GetImageCookie) *XProtoGetImageCookie {
+	return &XProtoGetImageCookie{cookie: c}
+}
+
+func (c *XProtoGetImageCookie) Reply() (*xproto.GetImageReply, error) {
+	return c.cookie.Reply()
+}
+
+type XProtoFreePixmapCookie struct {
+	cookie xproto.FreePixmapCookie
+}
+
+func NewXProtoFreePixmapCookie(c xproto.FreePixmapCookie) *XProtoFreePixmapCookie {
+	return &XProtoFreePixmapCookie{cookie: c}
+}
+
+func (c *XProtoFreePixmapCookie) Check() error {
+	return c.cookie.Check()
+}
+
+type XProtoNameWindowPixmapCookie struct {
+	cookie composite.NameWindowPixmapCookie
+}
+
+func NewXProtoNameWindowPixmapCookie(c composite.NameWindowPixmapCookie) *XProtoNameWindowPixmapCookie {
+	return &XProtoNameWindowPixmapCookie{cookie: c}
+}
+
+func (c *XProtoNameWindowPixmapCookie) Check() error {
+	return c.cookie.Check()
+}

--- a/screen/pixels.go
+++ b/screen/pixels.go
@@ -11,6 +11,9 @@ import (
 // This function is used by multiple backends (wlrscreencopy, extcapture, x11)
 // that all receive BGRA frames from the compositor or X server.
 func decodeBGRA(data []byte, w, h, stride int) *image.RGBA {
+	if len(data) == 0 || w <= 0 || h <= 0 {
+		return image.NewRGBA(image.Rect(0, 0, 0, 0))
+	}
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
 	rowBytes := w * 4
 	for row := 0; row < h; row++ {

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -9,9 +9,8 @@ import (
 	"hash/crc32"
 	"image"
 
-	"github.com/jezek/xgb"
-	"github.com/jezek/xgb/composite"
 	"github.com/jezek/xgb/xproto"
+	"github.com/nskaggs/perfuncted/internal/x11"
 )
 
 // GrabFullHash returns a CRC32 checksum of the entire screen.
@@ -23,9 +22,9 @@ func (b *X11Backend) GrabFullHash(ctx context.Context) (uint32, error) {
 		rawID, err := b.conn.NewId()
 		if err == nil {
 			pid := xproto.Pixmap(rawID)
-			if composite.NameWindowPixmap(b.conn, b.root, pid).Check() == nil {
+			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
 				drawable = xproto.Drawable(pid)
-				defer xproto.FreePixmap(b.conn, pid) //nolint:errcheck
+				defer b.conn.FreePixmap(pid) //nolint:errcheck
 			}
 		}
 	}
@@ -36,7 +35,7 @@ func (b *X11Backend) GrabFullHash(ctx context.Context) (uint32, error) {
 	h := uint16(rect.Dy())
 	planeMask := uint32(0xffffffff)
 
-	reply, err := xproto.GetImage(b.conn, xproto.ImageFormatZPixmap,
+	reply, err := b.conn.GetImage(xproto.ImageFormatZPixmap,
 		drawable, x, y, w, h, planeMask).Reply()
 	if err != nil {
 		return 0, fmt.Errorf("screen/x11: XGetImage: %w", err)
@@ -57,9 +56,9 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 		rawID, err := b.conn.NewId()
 		if err == nil {
 			pid := xproto.Pixmap(rawID)
-			if composite.NameWindowPixmap(b.conn, b.root, pid).Check() == nil {
+			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
 				drawable = xproto.Drawable(pid)
-				defer xproto.FreePixmap(b.conn, pid) //nolint:errcheck
+				defer b.conn.FreePixmap(pid) //nolint:errcheck
 			}
 		}
 	}
@@ -70,7 +69,7 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 	h := uint16(rect.Dy())
 	planeMask := uint32(0xffffffff)
 
-	reply, err := xproto.GetImage(b.conn, xproto.ImageFormatZPixmap,
+	reply, err := b.conn.GetImage(xproto.ImageFormatZPixmap,
 		drawable, x, y, w, h, planeMask).Reply()
 	if err != nil {
 		return 0, fmt.Errorf("screen/x11: XGetImage: %w", err)
@@ -89,7 +88,7 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 // On Wayland, only X11/XWayland window content is visible through this path;
 // native Wayland surfaces require Wayland capture protocols or portals.
 type X11Backend struct {
-	conn         *xgb.Conn
+	conn         x11.Connection
 	root         xproto.Window
 	screen       *xproto.ScreenInfo
 	hasComposite bool
@@ -98,14 +97,13 @@ type X11Backend struct {
 // NewX11Backend opens a connection to the X11 display specified by displayName
 // (e.g. ":0"). Pass an empty string to use the DISPLAY environment variable.
 func NewX11Backend(displayName string) (*X11Backend, error) {
-	conn, err := xgb.NewConnDisplay(displayName)
+	conn, err := x11.NewXgbConnection(displayName)
 	if err != nil {
 		return nil, fmt.Errorf("screen/x11: connect to display %q: %w", displayName, err)
 	}
-	setup := xproto.Setup(conn)
-	sc := setup.DefaultScreen(conn)
+	sc := conn.DefaultScreen()
 	b := &X11Backend{conn: conn, root: sc.Root, screen: sc}
-	if composite.Init(conn) == nil {
+	if b.conn.InitComposite() == nil {
 		b.hasComposite = true
 	}
 	return b, nil
@@ -123,9 +121,9 @@ func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Imag
 		rawID, err := b.conn.NewId()
 		if err == nil {
 			pid := xproto.Pixmap(rawID)
-			if composite.NameWindowPixmap(b.conn, b.root, pid).Check() == nil {
+			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
 				drawable = xproto.Drawable(pid)
-				defer xproto.FreePixmap(b.conn, pid) //nolint:errcheck
+				defer b.conn.FreePixmap(pid) //nolint:errcheck
 			}
 		}
 	}
@@ -136,7 +134,7 @@ func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Imag
 	h := uint16(rect.Dy())
 	planeMask := uint32(0xffffffff)
 
-	reply, err := xproto.GetImage(b.conn, xproto.ImageFormatZPixmap,
+	reply, err := b.conn.GetImage(xproto.ImageFormatZPixmap,
 		drawable, x, y, w, h, planeMask).Reply()
 	if err != nil {
 		return nil, fmt.Errorf("screen/x11: XGetImage: %w", err)

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -113,6 +113,9 @@ func NewX11Backend(displayName string) (*X11Backend, error) {
 // On composited displays it snapshots the root via NameWindowPixmap so that
 // the actual composited framebuffer is captured rather than the bare root pixmap.
 func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+	if rect.Empty() {
+		rect = image.Rect(0, 0, int(b.screen.WidthInPixels), int(b.screen.HeightInPixels))
+	}
 	drawable := xproto.Drawable(b.root)
 
 	if b.hasComposite {

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -143,6 +143,11 @@ func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Imag
 	return decodeBGRA(reply.Data, int(w), int(h), int(w)*4), nil
 }
 
+// Resolution returns the screen dimensions from the X11 screen info.
+func (b *X11Backend) Resolution() (int, int, error) {
+	return int(b.screen.WidthInPixels), int(b.screen.HeightInPixels), nil
+}
+
 // Close closes the X11 connection.
 func (b *X11Backend) Close() error {
 	b.conn.Close()

--- a/screen/x11_test.go
+++ b/screen/x11_test.go
@@ -1,0 +1,530 @@
+//go:build linux
+// +build linux
+
+package screen
+
+import (
+	"context"
+	"hash/crc32"
+	"image"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/nskaggs/perfuncted/internal/x11"
+)
+
+// Mock connection for testing screen X11 backend.
+type mockScreenConnection struct {
+	defaultScreenFn    func() *xproto.ScreenInfo
+	getImageFn         func(byte, xproto.Drawable, int16, int16, uint16, uint16, uint32) x11.GetImageCookie
+	newIdFn            func() (uint32, error)
+	freePixmapFn       func(xproto.Pixmap) x11.FreePixmapCookie
+	initCompositeFn    func() error
+	nameWindowPixmapFn func(xproto.Window, xproto.Pixmap) x11.NameWindowPixmapCookie
+}
+
+func (m *mockScreenConnection) Close() {}
+func (m *mockScreenConnection) DefaultScreen() *xproto.ScreenInfo {
+	if m.defaultScreenFn != nil {
+		return m.defaultScreenFn()
+	}
+	return &xproto.ScreenInfo{Root: 1, WidthInPixels: 1920, HeightInPixels: 1080}
+}
+func (m *mockScreenConnection) InternAtom(bool, uint16, string) x11.InternAtomCookie {
+	return &mockScreenInternAtomCookie{reply: &xproto.InternAtomReply{Atom: 1}}
+}
+func (m *mockScreenConnection) GetProperty(bool, xproto.Window, xproto.Atom, xproto.Atom, uint32, uint32) x11.GetPropertyCookie {
+	return &mockScreenGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+}
+func (m *mockScreenConnection) GetGeometry(xproto.Drawable) x11.GetGeometryCookie {
+	return &mockScreenGetGeometryCookie{reply: &xproto.GetGeometryReply{X: 0, Y: 0, Width: 100, Height: 100}}
+}
+func (m *mockScreenConnection) TranslateCoordinates(xproto.Window, xproto.Window, int16, int16) x11.TranslateCoordinatesCookie {
+	return &mockScreenTranslateCoordinatesCookie{reply: &xproto.TranslateCoordinatesReply{DstX: 0, DstY: 0}}
+}
+func (m *mockScreenConnection) SendEventChecked(bool, xproto.Window, uint32, string) x11.SendEventCookie {
+	return &mockScreenSendEventCookie{}
+}
+func (m *mockScreenConnection) MapWindowChecked(xproto.Window) x11.MapWindowCookie {
+	return &mockScreenMapWindowCookie{}
+}
+func (m *mockScreenConnection) ConfigureWindowChecked(xproto.Window, uint16, []uint32) x11.ConfigureWindowCookie {
+	return &mockScreenConfigureWindowCookie{}
+}
+func (m *mockScreenConnection) NewId() (uint32, error) {
+	if m.newIdFn != nil {
+		return m.newIdFn()
+	}
+	return 999, nil
+}
+func (m *mockScreenConnection) GetImage(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+	if m.getImageFn != nil {
+		return m.getImageFn(format, drawable, x, y, width, height, planeMask)
+	}
+	data := make([]byte, 4*4)
+	for i := range data {
+		data[i] = byte(i + 1)
+	}
+	return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+}
+func (m *mockScreenConnection) FreePixmap(p xproto.Pixmap) x11.FreePixmapCookie {
+	if m.freePixmapFn != nil {
+		return m.freePixmapFn(p)
+	}
+	return &mockScreenFreePixmapCookie{}
+}
+func (m *mockScreenConnection) InitComposite() error {
+	if m.initCompositeFn != nil {
+		return m.initCompositeFn()
+	}
+	return nil
+}
+func (m *mockScreenConnection) NameWindowPixmap(w xproto.Window, p xproto.Pixmap) x11.NameWindowPixmapCookie {
+	if m.nameWindowPixmapFn != nil {
+		return m.nameWindowPixmapFn(w, p)
+	}
+	return &mockScreenNameWindowPixmapCookie{}
+}
+
+// Mock cookies for screen tests.
+type mockScreenInternAtomCookie struct {
+	reply *xproto.InternAtomReply
+	err   error
+}
+
+func (m *mockScreenInternAtomCookie) Reply() (*xproto.InternAtomReply, error) {
+	return m.reply, m.err
+}
+
+type mockScreenGetPropertyCookie struct {
+	reply *xproto.GetPropertyReply
+	err   error
+}
+
+func (m *mockScreenGetPropertyCookie) Reply() (*xproto.GetPropertyReply, error) {
+	return m.reply, m.err
+}
+
+type mockScreenGetGeometryCookie struct {
+	reply *xproto.GetGeometryReply
+	err   error
+}
+
+func (m *mockScreenGetGeometryCookie) Reply() (*xproto.GetGeometryReply, error) {
+	return m.reply, m.err
+}
+
+type mockScreenTranslateCoordinatesCookie struct {
+	reply *xproto.TranslateCoordinatesReply
+	err   error
+}
+
+func (m *mockScreenTranslateCoordinatesCookie) Reply() (*xproto.TranslateCoordinatesReply, error) {
+	return m.reply, m.err
+}
+
+type mockScreenSendEventCookie struct{ err error }
+
+func (m *mockScreenSendEventCookie) Check() error { return m.err }
+
+type mockScreenMapWindowCookie struct{ err error }
+
+func (m *mockScreenMapWindowCookie) Check() error { return m.err }
+
+type mockScreenConfigureWindowCookie struct{ err error }
+
+func (m *mockScreenConfigureWindowCookie) Check() error { return m.err }
+
+type mockScreenGetImageCookie struct {
+	reply *xproto.GetImageReply
+	err   error
+}
+
+func (m *mockScreenGetImageCookie) Reply() (*xproto.GetImageReply, error) {
+	if m.reply != nil {
+		return m.reply, m.err
+	}
+	return &xproto.GetImageReply{}, m.err
+}
+
+type mockScreenFreePixmapCookie struct{ err error }
+
+func (m *mockScreenFreePixmapCookie) Check() error { return m.err }
+
+type mockScreenNameWindowPixmapCookie struct{ err error }
+
+func (m *mockScreenNameWindowPixmapCookie) Check() error { return m.err }
+
+// newStubScreenX11Backend creates a test X11Backend for screen capture.
+func newStubScreenX11Backend(t *testing.T, hasComposite bool) *X11Backend {
+	t.Helper()
+	conn := &mockScreenConnection{}
+	b := &X11Backend{
+		conn:         conn,
+		root:         1,
+		screen:       &xproto.ScreenInfo{Root: 1, WidthInPixels: 1920, HeightInPixels: 1080},
+		hasComposite: hasComposite,
+	}
+	conn.defaultScreenFn = func() *xproto.ScreenInfo {
+		return b.screen
+	}
+	return b
+}
+
+func TestX11Backend_Grab(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	rect := image.Rect(0, 0, 2, 2)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	if img.Bounds().Dx() != 2 || img.Bounds().Dy() != 2 {
+		t.Errorf("Grab() image size = %dx%d, want 2x2", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestX11Backend_Grab_EmptyRect(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	// Empty rect should grab full screen - set up mock to return full screen data
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		// Create data for full screen (1920x1080)
+		data := make([]byte, int(width)*int(height)*4)
+		for i := range data {
+			data[i] = byte(i%255 + 1)
+		}
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 0, 0)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	if img.Bounds().Dx() == 0 || img.Bounds().Dy() == 0 {
+		t.Errorf("Grab() with empty rect should grab full screen, got %dx%d", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestX11Backend_Grab_WithComposite(t *testing.T) {
+	var pixmapCreated bool
+	b := newStubScreenX11Backend(t, true)
+	b.conn.(*mockScreenConnection).newIdFn = func() (uint32, error) {
+		return 100, nil
+	}
+	b.conn.(*mockScreenConnection).nameWindowPixmapFn = func(w xproto.Window, p xproto.Pixmap) x11.NameWindowPixmapCookie {
+		pixmapCreated = true
+		return &mockScreenNameWindowPixmapCookie{}
+	}
+	// Set up GetImage to return data for 100x100 image
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		data := make([]byte, int(width)*int(height)*4)
+		for i := range data {
+			data[i] = byte(i%255 + 1)
+		}
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 100, 100)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	if img == nil {
+		t.Fatal("Grab() returned nil image")
+	}
+	if !pixmapCreated {
+		t.Error("Grab() with composite should have created a pixmap via NameWindowPixmap")
+	}
+}
+
+func TestX11Backend_Grab_WithoutComposite(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	// Set up GetImage to return data for 100x100 image
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		data := make([]byte, int(width)*int(height)*4)
+		for i := range data {
+			data[i] = byte(i%255 + 1)
+		}
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(10, 20, 110, 120)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	if img.Bounds().Dx() != 100 || img.Bounds().Dy() != 100 {
+		t.Errorf("Grab() image size = %dx%d, want 100x100", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestX11Backend_Grab_Error(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{err: image.ErrFormat}
+	}
+	rect := image.Rect(0, 0, 100, 100)
+	_, err := b.Grab(context.Background(), rect)
+	if err == nil || !strings.Contains(err.Error(), "XGetImage") {
+		t.Errorf("Grab() error = %v, want error containing %q", err, "XGetImage")
+	}
+}
+
+func TestX11Backend_GrabFullHash(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedHash := crc32.ChecksumIEEE(data)
+
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	hash, err := b.GrabFullHash(context.Background())
+	if err != nil {
+		t.Fatalf("GrabFullHash() unexpected error: %v", err)
+	}
+	if hash != expectedHash {
+		t.Errorf("GrabFullHash() = %d, want %d", hash, expectedHash)
+	}
+}
+
+func TestX11Backend_GrabFullHash_WithComposite(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedHash := crc32.ChecksumIEEE(data)
+
+	b := newStubScreenX11Backend(t, true)
+	b.conn.(*mockScreenConnection).newIdFn = func() (uint32, error) {
+		return 100, nil
+	}
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	hash, err := b.GrabFullHash(context.Background())
+	if err != nil {
+		t.Fatalf("GrabFullHash() unexpected error: %v", err)
+	}
+	if hash != expectedHash {
+		t.Errorf("GrabFullHash() = %d, want %d", hash, expectedHash)
+	}
+}
+
+func TestX11Backend_GrabRegionHash(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedHash := crc32.ChecksumIEEE(data)
+
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 2, 2)
+	hash, err := b.GrabRegionHash(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("GrabRegionHash() unexpected error: %v", err)
+	}
+	if hash != expectedHash {
+		t.Errorf("GrabRegionHash() = %d, want %d", hash, expectedHash)
+	}
+}
+
+func TestX11Backend_GrabRegionHash_EmptyRect(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	hash1, _ := b.GrabFullHash(context.Background())
+	hash2, err := b.GrabRegionHash(context.Background(), image.Rect(0, 0, 0, 0))
+	if err != nil {
+		t.Fatalf("GrabRegionHash() unexpected error: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("GrabRegionHash(empty rect) = %d, want %d (same as GrabFullHash)", hash2, hash1)
+	}
+}
+
+func TestX11Backend_GrabRegionHash_WithComposite(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedHash := crc32.ChecksumIEEE(data)
+
+	b := newStubScreenX11Backend(t, true)
+	b.conn.(*mockScreenConnection).newIdFn = func() (uint32, error) {
+		return 100, nil
+	}
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(10, 20, 110, 120)
+	hash, err := b.GrabRegionHash(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("GrabRegionHash() unexpected error: %v", err)
+	}
+	if hash != expectedHash {
+		t.Errorf("GrabRegionHash() = %d, want %d", hash, expectedHash)
+	}
+}
+
+func TestX11Backend_New_NoDisplay(t *testing.T) {
+	orig := os.Getenv("DISPLAY")
+	os.Unsetenv("DISPLAY")
+	defer os.Setenv("DISPLAY", orig)
+	_, err := NewX11Backend("")
+	if err == nil || !strings.Contains(err.Error(), "screen/x11: connect to display") {
+		t.Fatalf("NewX11Backend() error = %v, want connection error", err)
+	}
+}
+
+func TestX11Backend_Close(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	if err := b.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+}
+
+func TestX11Backend_Grab_ColorCheck(t *testing.T) {
+	data := []byte{1, 2, 3, 255}
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 1, 1)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	rgba, ok := img.(*image.RGBA)
+	if !ok {
+		t.Fatal("Grab() did not return *image.RGBA")
+	}
+	c := rgba.RGBAAt(0, 0)
+	if c.R != 3 || c.G != 2 || c.B != 1 || c.A != 255 {
+		t.Errorf("Grab() pixel = RGBA(%d,%d,%d,%d), want RGBA(3,2,1,255)", c.R, c.G, c.B, c.A)
+	}
+}
+
+func TestX11Backend_Resolution(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	w, h, err := Resolution(b)
+	if err != nil {
+		t.Fatalf("Resolution() unexpected error: %v", err)
+	}
+	if w != 1920 || h != 1080 {
+		t.Errorf("Resolution() = %dx%d, want 1920x1080", w, h)
+	}
+}
+
+func TestX11Backend_ImplementsScreenshotter(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	var _ Screenshotter = b
+}
+
+func TestX11Backend_ImplementsResolver(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	var _ Resolver = b
+}
+
+func TestDecodeBGRA_Integration(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	data := []byte{
+		10, 20, 30, 255,
+		40, 50, 60, 255,
+		70, 80, 90, 255,
+		100, 110, 120, 255,
+	}
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 2, 2)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	rgba, ok := img.(*image.RGBA)
+	if !ok {
+		t.Fatal("Grab() did not return *image.RGBA")
+	}
+	tests := []struct {
+		x, y    int
+		r, g, b uint8
+	}{
+		{0, 0, 30, 20, 10},
+		{1, 0, 60, 50, 40},
+		{0, 1, 90, 80, 70},
+		{1, 1, 120, 110, 100},
+	}
+	for _, tc := range tests {
+		c := rgba.RGBAAt(tc.x, tc.y)
+		if c.R != tc.r || c.G != tc.g || c.B != tc.b {
+			t.Errorf("(%d,%d): got RGB(%d,%d,%d) want RGB(%d,%d,%d)",
+				tc.x, tc.y, c.R, c.G, c.B, tc.r, tc.g, tc.b)
+		}
+	}
+}
+
+func TestX11Backend_GrabFullHash_Error(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{err: image.ErrFormat}
+	}
+	_, err := b.GrabFullHash(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "XGetImage") {
+		t.Errorf("GrabFullHash() error = %v, want error containing %q", err, "XGetImage")
+	}
+}
+
+func TestX11Backend_GrabRegionHash_Error(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{err: image.ErrFormat}
+	}
+	rect := image.Rect(0, 0, 100, 100)
+	_, err := b.GrabRegionHash(context.Background(), rect)
+	if err == nil || !strings.Contains(err.Error(), "XGetImage") {
+		t.Errorf("GrabRegionHash() error = %v, want error containing %q", err, "XGetImage")
+	}
+}
+
+func TestX11Backend_Grab_ImageCheck(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	data := make([]byte, 4*4*4)
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			off := (y*2 + x) * 4
+			data[off] = byte(x * 10)
+			data[off+1] = byte(y * 10)
+			data[off+2] = byte(x * y * 10)
+			data[off+3] = 255
+		}
+	}
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}}
+	}
+	rect := image.Rect(0, 0, 2, 2)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	if img == nil {
+		t.Fatal("Grab() returned nil image")
+	}
+	rgba, ok := img.(*image.RGBA)
+	if !ok {
+		t.Fatal("Grab() did not return *image.RGBA")
+	}
+	if rgba.Bounds().Dx() != 2 || rgba.Bounds().Dy() != 2 {
+		t.Errorf("Grab() image size = %dx%d, want 2x2", rgba.Bounds().Dx(), rgba.Bounds().Dy())
+	}
+	c := rgba.RGBAAt(1, 1)
+	if c.R != 10 || c.G != 10 || c.B != 10 {
+		t.Errorf("Grab() pixel (1,1) = RGB(%d,%d,%d), want RGB(10,10,10)", c.R, c.G, c.B)
+	}
+}
+
+func TestX11Backend_Grab_NilImage(t *testing.T) {
+	b := newStubScreenX11Backend(t, false)
+	b.conn.(*mockScreenConnection).getImageFn = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+		return &mockScreenGetImageCookie{reply: &xproto.GetImageReply{Depth: 24, Visual: 1, Data: nil}}
+	}
+	rect := image.Rect(0, 0, 10, 10)
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab() unexpected error: %v", err)
+	}
+	// Nil data should result in an empty image
+	if img == nil {
+		t.Fatal("Grab() returned nil image for nil data")
+	}
+}

--- a/window/x11.go
+++ b/window/x11.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 	"iter"
 
-	"github.com/jezek/xgb"
 	"github.com/jezek/xgb/xproto"
+	"github.com/nskaggs/perfuncted/internal/x11"
 )
 
 var _ Manager = (*X11Backend)(nil)
 
 // X11Backend manages windows via EWMH atoms on an X11 or XWayland display.
 type X11Backend struct {
-	conn                *xgb.Conn
+	conn                x11.Connection
 	root                xproto.Window
 	atomNetClientList   xproto.Atom
 	atomNetActiveWindow xproto.Atom
@@ -30,12 +30,12 @@ type X11Backend struct {
 // NewX11Backend connects to the X11 display and interns the EWMH atoms needed
 // for window management. Pass an empty string to use the DISPLAY environment variable.
 func NewX11Backend(displayName string) (*X11Backend, error) {
-	conn, err := xgb.NewConnDisplay(displayName)
+	conn, err := x11.NewXgbConnection(displayName)
 	if err != nil {
 		return nil, fmt.Errorf("window/x11: connect to display %q: %w", displayName, err)
 	}
 	b := &X11Backend{conn: conn}
-	b.root = xproto.Setup(conn).DefaultScreen(conn).Root
+	b.root = b.conn.DefaultScreen().Root
 
 	atoms := map[string]*xproto.Atom{
 		"_NET_CLIENT_LIST":   &b.atomNetClientList,
@@ -47,7 +47,7 @@ func NewX11Backend(displayName string) (*X11Backend, error) {
 		"UTF8_STRING":        &b.atomUTF8String,
 	}
 	for name, ptr := range atoms {
-		reply, err := xproto.InternAtom(conn, false, uint16(len(name)), name).Reply()
+		reply, err := b.conn.InternAtom(false, uint16(len(name)), name).Reply()
 		if err != nil {
 			conn.Close()
 			return nil, fmt.Errorf("window/x11: intern atom %q: %w", name, err)
@@ -60,13 +60,13 @@ func NewX11Backend(displayName string) (*X11Backend, error) {
 // windowTitle returns the title of a window, trying _NET_WM_NAME then WM_NAME.
 func (b *X11Backend) windowTitle(win xproto.Window) string {
 	// Try _NET_WM_NAME (UTF-8) first.
-	rep, err := xproto.GetProperty(b.conn, false, win, b.atomNetWMName,
+	rep, err := b.conn.GetProperty(false, win, b.atomNetWMName,
 		b.atomUTF8String, 0, 1024).Reply()
 	if err == nil && len(rep.Value) > 0 {
 		return string(rep.Value)
 	}
 	// Fallback: WM_NAME (Latin-1).
-	rep, err = xproto.GetProperty(b.conn, false, win, xproto.AtomWmName,
+	rep, err = b.conn.GetProperty(false, win, xproto.AtomWmName,
 		xproto.AtomString, 0, 1024).Reply()
 	if err == nil && len(rep.Value) > 0 {
 		return string(rep.Value)
@@ -76,7 +76,7 @@ func (b *X11Backend) windowTitle(win xproto.Window) string {
 
 // windowPID returns the PID stored in _NET_WM_PID, or 0 if unavailable.
 func (b *X11Backend) windowPID(win xproto.Window) int32 {
-	rep, err := xproto.GetProperty(b.conn, false, win, b.atomNetWMPID,
+	rep, err := b.conn.GetProperty(false, win, b.atomNetWMPID,
 		xproto.AtomCardinal, 0, 1).Reply()
 	if err != nil || len(rep.Value) < 4 {
 		return 0
@@ -90,7 +90,7 @@ func (b *X11Backend) windowPID(win xproto.Window) int32 {
 // this "trick" allows them to bypass the decoration settings which is done by WM ; the WM allocates the decoration
 // space (because of _NET_FRAME_EXTENTS) but does not draw them, leaving this task to the application itself.
 func (b *X11Backend) windowHasDecoration(win xproto.Window) bool {
-	rep, err := xproto.GetProperty(b.conn, false, win, b.atomMotifWMHints,
+	rep, err := b.conn.GetProperty(false, win, b.atomMotifWMHints,
 		b.atomMotifWMHints, 0, 5).Reply()
 	if err != nil || len(rep.Value) < 20 {
 		return true
@@ -106,12 +106,12 @@ func (b *X11Backend) windowHasDecoration(win xproto.Window) bool {
 
 // windowGeometry returns the geometry of a window, including its decoration
 func (b *X11Backend) windowGeometry(win xproto.Window) (int, int, int, int) {
-	geo, err := xproto.GetGeometry(b.conn, xproto.Drawable(win)).Reply()
+	geo, err := b.conn.GetGeometry(xproto.Drawable(win)).Reply()
 	if err != nil {
 		return 0, 0, 0, 0
 	}
 
-	trans, err := xproto.TranslateCoordinates(b.conn, win, b.root, 0, 0).Reply()
+	trans, err := b.conn.TranslateCoordinates(win, b.root, 0, 0).Reply()
 	if err != nil {
 		return int(geo.X), int(geo.Y), int(geo.Width), int(geo.Height)
 	}
@@ -126,7 +126,7 @@ func (b *X11Backend) windowGeometry(win xproto.Window) (int, int, int, int) {
 	h := int(geo.Height)
 
 	// decorated windows shall be translated again by the size of the decorations
-	reply, err := xproto.GetProperty(b.conn, false, win, b.atomNetFrameExtent,
+	reply, err := b.conn.GetProperty(false, win, b.atomNetFrameExtent,
 		xproto.AtomCardinal, 0, 4).Reply()
 	if err == nil && len(reply.Value) == 16 {
 		left := int(uint32(reply.Value[0]) | uint32(reply.Value[1])<<8 | uint32(reply.Value[2])<<16 | uint32(reply.Value[3])<<24)
@@ -157,7 +157,7 @@ func (b *X11Backend) List(ctx context.Context) ([]Info, error) {
 // IterateWindows returns an iterator over all top-level windows.
 func (b *X11Backend) IterateWindows(ctx context.Context) iter.Seq2[Info, error] {
 	return func(yield func(Info, error) bool) {
-		rep, err := xproto.GetProperty(b.conn, false, b.root, b.atomNetClientList,
+		rep, err := b.conn.GetProperty(false, b.root, b.atomNetClientList,
 			xproto.AtomWindow, 0, 1024).Reply()
 		if err != nil {
 			yield(Info{}, fmt.Errorf("window/x11: get _NET_CLIENT_LIST: %w", err))
@@ -208,7 +208,7 @@ func (b *X11Backend) Activate(ctx context.Context, title string) error {
 		return err
 	}
 	data := []uint32{1, uint32(xproto.TimeCurrentTime), 0, 0, 0}
-	return xproto.SendEventChecked(b.conn, false, b.root,
+	return b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
@@ -224,20 +224,20 @@ func (b *X11Backend) Restore(ctx context.Context, title string) error {
 	if err != nil {
 		return err
 	}
-	stateAtom, err := xproto.InternAtom(b.conn, false, 14, "_NET_WM_STATE").Reply()
+	stateAtom, err := b.conn.InternAtom(false, 14, "_NET_WM_STATE").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE: %w", err)
 	}
-	maxV, err := xproto.InternAtom(b.conn, false, 28, "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
+	maxV, err := b.conn.InternAtom(false, 28, "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_VERT: %w", err)
 	}
-	maxH, err := xproto.InternAtom(b.conn, false, 28, "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
+	maxH, err := b.conn.InternAtom(false, 28, "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_HORZ: %w", err)
 	}
 	data := [5]uint32{0 /* _NET_WM_STATE_REMOVE */, uint32(maxV.Atom), uint32(maxH.Atom), 1, 0}
-	if err := xproto.SendEventChecked(b.conn, false, b.root,
+	if err := b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
@@ -247,7 +247,7 @@ func (b *X11Backend) Restore(ctx context.Context, title string) error {
 		}.Bytes())).Check(); err != nil {
 		return err
 	}
-	return xproto.MapWindowChecked(b.conn, win).Check()
+	return b.conn.MapWindowChecked(win).Check()
 }
 
 // Move repositions a window by title.
@@ -256,7 +256,7 @@ func (b *X11Backend) Move(ctx context.Context, title string, x, y int) error {
 	if err != nil {
 		return err
 	}
-	return xproto.ConfigureWindowChecked(b.conn, win,
+	return b.conn.ConfigureWindowChecked(win,
 		xproto.ConfigWindowX|xproto.ConfigWindowY,
 		[]uint32{uint32(x), uint32(y)}).Check()
 }
@@ -267,14 +267,14 @@ func (b *X11Backend) Resize(ctx context.Context, title string, w, h int) error {
 	if err != nil {
 		return err
 	}
-	return xproto.ConfigureWindowChecked(b.conn, win,
+	return b.conn.ConfigureWindowChecked(win,
 		xproto.ConfigWindowWidth|xproto.ConfigWindowHeight,
 		[]uint32{uint32(w), uint32(h)}).Check()
 }
 
 // ActiveTitle returns the title of the currently focused window.
 func (b *X11Backend) ActiveTitle(ctx context.Context) (string, error) {
-	rep, err := xproto.GetProperty(b.conn, false, b.root, b.atomNetActiveWindow,
+	rep, err := b.conn.GetProperty(false, b.root, b.atomNetActiveWindow,
 		xproto.AtomWindow, 0, 1).Reply()
 	if err != nil {
 		return "", fmt.Errorf("window/x11: get _NET_ACTIVE_WINDOW: %w", err)
@@ -300,16 +300,16 @@ func (b *X11Backend) CloseWindow(ctx context.Context, title string) error {
 		return err
 	}
 	// Intern WM_DELETE_WINDOW and WM_PROTOCOLS atoms.
-	delAtom, err := xproto.InternAtom(b.conn, false, 18, "WM_DELETE_WINDOW").Reply()
+	delAtom, err := b.conn.InternAtom(false, 18, "WM_DELETE_WINDOW").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern WM_DELETE_WINDOW: %w", err)
 	}
-	protoAtom, err := xproto.InternAtom(b.conn, false, 12, "WM_PROTOCOLS").Reply()
+	protoAtom, err := b.conn.InternAtom(false, 12, "WM_PROTOCOLS").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern WM_PROTOCOLS: %w", err)
 	}
 	data := [5]uint32{uint32(delAtom.Atom), uint32(xproto.TimeCurrentTime), 0, 0, 0}
-	return xproto.SendEventChecked(b.conn, false, win, 0,
+	return b.conn.SendEventChecked(false, win, 0,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
 			Window: win,
@@ -325,12 +325,12 @@ func (b *X11Backend) Minimize(ctx context.Context, title string) error {
 		return err
 	}
 	// Use XIconifyWindow via ChangeProperty with WM_CHANGE_STATE.
-	csAtom, err := xproto.InternAtom(b.conn, false, 15, "WM_CHANGE_STATE").Reply()
+	csAtom, err := b.conn.InternAtom(false, 15, "WM_CHANGE_STATE").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern WM_CHANGE_STATE: %w", err)
 	}
 	data := [5]uint32{3 /* IconicState */, 0, 0, 0, 0}
-	return xproto.SendEventChecked(b.conn, false, b.root,
+	return b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
@@ -346,20 +346,20 @@ func (b *X11Backend) Maximize(ctx context.Context, title string) error {
 	if err != nil {
 		return err
 	}
-	stateAtom, err := xproto.InternAtom(b.conn, false, 14, "_NET_WM_STATE").Reply()
+	stateAtom, err := b.conn.InternAtom(false, 14, "_NET_WM_STATE").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE: %w", err)
 	}
-	maxV, err := xproto.InternAtom(b.conn, false, 28, "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
+	maxV, err := b.conn.InternAtom(false, 28, "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_VERT: %w", err)
 	}
-	maxH, err := xproto.InternAtom(b.conn, false, 28, "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
+	maxH, err := b.conn.InternAtom(false, 28, "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_HORZ: %w", err)
 	}
 	data := [5]uint32{1 /* _NET_WM_STATE_ADD */, uint32(maxV.Atom), uint32(maxH.Atom), 1 /* source = application */, 0}
-	return xproto.SendEventChecked(b.conn, false, b.root,
+	return b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,

--- a/window/x11.go
+++ b/window/x11.go
@@ -101,7 +101,12 @@ func (b *X11Backend) windowHasDecoration(win xproto.Window) bool {
 
 	const MwmHintsDecorations = 1 << 1
 
-	return (flags&MwmHintsDecorations) != 0 || (decorations != 0)
+	// If the app didn't set MwmHintsDecorations, default is to have decorations.
+	// If it did set the flag, use the decorations value (0 = no decorations).
+	if (flags & MwmHintsDecorations) == 0 {
+		return true
+	}
+	return decorations != 0
 }
 
 // windowGeometry returns the geometry of a window, including its decoration

--- a/window/x11_test.go
+++ b/window/x11_test.go
@@ -1,0 +1,534 @@
+//go:build linux
+// +build linux
+
+package window
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/nskaggs/perfuncted/internal/x11"
+)
+
+// Mock connection for testing X11 backend.
+type mockConnection struct {
+	defaultScreenFn          func() *xproto.ScreenInfo
+	internAtomFn             func(bool, uint16, string) x11.InternAtomCookie
+	getPropertyFn            func(bool, xproto.Window, xproto.Atom, xproto.Atom, uint32, uint32) x11.GetPropertyCookie
+	getGeometryFn            func(xproto.Drawable) x11.GetGeometryCookie
+	translateCoordinatesFn   func(xproto.Window, xproto.Window, int16, int16) x11.TranslateCoordinatesCookie
+	sendEventCheckedFn       func(bool, xproto.Window, uint32, string) x11.SendEventCookie
+	mapWindowCheckedFn       func(xproto.Window) x11.MapWindowCookie
+	configureWindowCheckedFn func(xproto.Window, uint16, []uint32) x11.ConfigureWindowCookie
+	newIdFn                  func() (uint32, error)
+}
+
+func (m *mockConnection) Close() {}
+func (m *mockConnection) DefaultScreen() *xproto.ScreenInfo {
+	if m.defaultScreenFn != nil {
+		return m.defaultScreenFn()
+	}
+	return &xproto.ScreenInfo{Root: 1, WidthInPixels: 1920, HeightInPixels: 1080}
+}
+func (m *mockConnection) InternAtom(o bool, l uint16, n string) x11.InternAtomCookie {
+	if m.internAtomFn != nil {
+		return m.internAtomFn(o, l, n)
+	}
+	return &mockInternAtomCookie{reply: &xproto.InternAtomReply{Atom: 1}}
+}
+func (m *mockConnection) GetProperty(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+	if m.getPropertyFn != nil {
+		return m.getPropertyFn(d, w, p, t, lo, ll)
+	}
+	return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+}
+func (m *mockConnection) GetGeometry(d xproto.Drawable) x11.GetGeometryCookie {
+	if m.getGeometryFn != nil {
+		return m.getGeometryFn(d)
+	}
+	return &mockGetGeometryCookie{reply: &xproto.GetGeometryReply{X: 0, Y: 0, Width: 100, Height: 100}}
+}
+func (m *mockConnection) TranslateCoordinates(s, d xproto.Window, x, y int16) x11.TranslateCoordinatesCookie {
+	if m.translateCoordinatesFn != nil {
+		return m.translateCoordinatesFn(s, d, x, y)
+	}
+	return &mockTranslateCoordinatesCookie{reply: &xproto.TranslateCoordinatesReply{DstX: 0, DstY: 0}}
+}
+func (m *mockConnection) SendEventChecked(p bool, dest xproto.Window, mask uint32, ev string) x11.SendEventCookie {
+	if m.sendEventCheckedFn != nil {
+		return m.sendEventCheckedFn(p, dest, mask, ev)
+	}
+	return &mockSendEventCookie{}
+}
+func (m *mockConnection) MapWindowChecked(w xproto.Window) x11.MapWindowCookie {
+	if m.mapWindowCheckedFn != nil {
+		return m.mapWindowCheckedFn(w)
+	}
+	return &mockMapWindowCookie{}
+}
+func (m *mockConnection) ConfigureWindowChecked(w xproto.Window, mask uint16, vals []uint32) x11.ConfigureWindowCookie {
+	if m.configureWindowCheckedFn != nil {
+		return m.configureWindowCheckedFn(w, mask, vals)
+	}
+	return &mockConfigureWindowCookie{}
+}
+func (m *mockConnection) NewId() (uint32, error) {
+	if m.newIdFn != nil {
+		return m.newIdFn()
+	}
+	return 999, nil
+}
+func (m *mockConnection) GetImage(b byte, d xproto.Drawable, x, y int16, w, h uint16, pm uint32) x11.GetImageCookie {
+	return &mockGetImageCookie{}
+}
+func (m *mockConnection) FreePixmap(xproto.Pixmap) x11.FreePixmapCookie {
+	return &mockFreePixmapCookie{}
+}
+func (m *mockConnection) InitComposite() error { return nil }
+func (m *mockConnection) NameWindowPixmap(xproto.Window, xproto.Pixmap) x11.NameWindowPixmapCookie {
+	return &mockNameWindowPixmapCookie{}
+}
+
+// Mock cookies.
+type mockInternAtomCookie struct {
+	reply *xproto.InternAtomReply
+	err   error
+}
+
+func (m *mockInternAtomCookie) Reply() (*xproto.InternAtomReply, error) {
+	return m.reply, m.err
+}
+
+type mockGetPropertyCookie struct {
+	reply *xproto.GetPropertyReply
+	err   error
+}
+
+func (m *mockGetPropertyCookie) Reply() (*xproto.GetPropertyReply, error) {
+	return m.reply, m.err
+}
+
+type mockGetGeometryCookie struct {
+	reply *xproto.GetGeometryReply
+	err   error
+}
+
+func (m *mockGetGeometryCookie) Reply() (*xproto.GetGeometryReply, error) {
+	return m.reply, m.err
+}
+
+type mockTranslateCoordinatesCookie struct {
+	reply *xproto.TranslateCoordinatesReply
+	err   error
+}
+
+func (m *mockTranslateCoordinatesCookie) Reply() (*xproto.TranslateCoordinatesReply, error) {
+	return m.reply, m.err
+}
+
+type mockSendEventCookie struct{ err error }
+
+func (m *mockSendEventCookie) Check() error { return m.err }
+
+type mockMapWindowCookie struct{ err error }
+
+func (m *mockMapWindowCookie) Check() error { return m.err }
+
+type mockConfigureWindowCookie struct{ err error }
+
+func (m *mockConfigureWindowCookie) Check() error { return m.err }
+
+type mockGetImageCookie struct{}
+
+func (m *mockGetImageCookie) Reply() (*xproto.GetImageReply, error) {
+	return &xproto.GetImageReply{}, nil
+}
+
+type mockFreePixmapCookie struct{ err error }
+
+func (m *mockFreePixmapCookie) Check() error { return m.err }
+
+type mockNameWindowPixmapCookie struct{ err error }
+
+func (m *mockNameWindowPixmapCookie) Check() error { return m.err }
+
+// newStubX11Backend creates a test X11Backend with mock connection and atoms.
+func newStubX11Backend(t *testing.T, withWindow bool, title string) *X11Backend {
+	t.Helper()
+	conn := &mockConnection{}
+	b := &X11Backend{
+		conn:                conn,
+		root:                1,
+		atomNetClientList:   10,
+		atomNetActiveWindow: 11,
+		atomNetFrameExtent:  12,
+		atomNetWMName:       13,
+		atomNetWMPID:        14,
+		atomMotifWMHints:    15,
+		atomUTF8String:      16,
+	}
+	conn.defaultScreenFn = func() *xproto.ScreenInfo {
+		return &xproto.ScreenInfo{Root: b.root, WidthInPixels: 1920, HeightInPixels: 1080}
+	}
+	if withWindow {
+		wid := xproto.Window(50)
+		titleBytes := []byte(title)
+		conn.getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+			switch p {
+			case b.atomNetClientList:
+				return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{byte(wid), byte(wid >> 8), byte(wid >> 16), byte(wid >> 24)}}}
+			case b.atomNetWMName:
+				return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 8, Value: titleBytes}}
+			case b.atomNetWMPID:
+				return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{1, 0, 0, 0}}}
+			case b.atomNetActiveWindow:
+				return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+			case b.atomNetFrameExtent, b.atomMotifWMHints:
+				return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+			}
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+		}
+		conn.getGeometryFn = func(d xproto.Drawable) x11.GetGeometryCookie {
+			return &mockGetGeometryCookie{reply: &xproto.GetGeometryReply{X: 10, Y: 20, Width: 800, Height: 600}}
+		}
+		conn.translateCoordinatesFn = func(s, d xproto.Window, x, y int16) x11.TranslateCoordinatesCookie {
+			return &mockTranslateCoordinatesCookie{reply: &xproto.TranslateCoordinatesReply{DstX: 10, DstY: 20}}
+		}
+	}
+	return b
+}
+
+func TestX11Backend_New_NoDisplay(t *testing.T) {
+	orig := os.Getenv("DISPLAY")
+	os.Unsetenv("DISPLAY")
+	defer os.Setenv("DISPLAY", orig)
+	_, err := NewX11Backend("")
+	if err == nil || !strings.Contains(err.Error(), "window/x11: connect to display") {
+		t.Fatalf("NewX11Backend() error = %v, want connection error", err)
+	}
+}
+
+func TestX11Backend_List(t *testing.T) {
+	b := newStubX11Backend(t, true, "Test Window")
+	wins, err := b.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() unexpected error: %v", err)
+	}
+	if len(wins) != 1 || wins[0].Title != "Test Window" {
+		t.Errorf("List() = %+v, want 1 window titled %q", wins, "Test Window")
+	}
+}
+
+func TestX11Backend_List_Empty(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	wins, err := b.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() unexpected error: %v", err)
+	}
+	if len(wins) != 0 {
+		t.Errorf("List() expected 0 windows, got %d", len(wins))
+	}
+}
+
+func TestX11Backend_List_GetPropertyError(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		return &mockGetPropertyCookie{err: fmt.Errorf("simulated error")}
+	}
+	_, err := b.List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "get _NET_CLIENT_LIST") {
+		t.Errorf("List() error = %v, want error containing %q", err, "get _NET_CLIENT_LIST")
+	}
+}
+
+func TestX11Backend_List_UnexpectedFormat(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 8, Value: []byte{1, 2, 3}}}
+	}
+	_, err := b.List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "unexpected _NET_CLIENT_LIST format") {
+		t.Errorf("List() error = %v, want error containing format", err)
+	}
+}
+
+func runX11ActionTest(t *testing.T, name, title string, windowExists bool, action func(*X11Backend, context.Context, string) error) {
+	t.Helper()
+	t.Run("Window exists", func(t *testing.T) {
+		var events []string
+		b := newStubX11Backend(t, true, title)
+		b.conn.(*mockConnection).sendEventCheckedFn = func(p bool, dest xproto.Window, mask uint32, ev string) x11.SendEventCookie {
+			events = append(events, ev)
+			return &mockSendEventCookie{}
+		}
+		if err := action(b, context.Background(), title); err != nil {
+			t.Errorf("%s() unexpected error: %v", name, err)
+		}
+		if len(events) == 0 {
+			t.Errorf("%s() did not send event", name)
+		}
+	})
+	t.Run("Window does not exist", func(t *testing.T) {
+		b := newStubX11Backend(t, false, "")
+		err := action(b, context.Background(), "Nonexistent")
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("%s() error = %v, want error containing %q", name, err, "not found")
+		}
+	})
+}
+
+func TestX11Backend_Activate(t *testing.T) {
+	runX11ActionTest(t, "Activate", "ActivateMe", true, func(b *X11Backend, ctx context.Context, title string) error {
+		return b.Activate(ctx, title)
+	})
+}
+
+func TestX11Backend_CloseWindow(t *testing.T) {
+	runX11ActionTest(t, "CloseWindow", "CloseMe", true, func(b *X11Backend, ctx context.Context, title string) error {
+		return b.CloseWindow(ctx, title)
+	})
+}
+
+func TestX11Backend_Minimize(t *testing.T) {
+	runX11ActionTest(t, "Minimize", "MinimizeMe", true, func(b *X11Backend, ctx context.Context, title string) error {
+		return b.Minimize(ctx, title)
+	})
+}
+
+func TestX11Backend_Maximize(t *testing.T) {
+	runX11ActionTest(t, "Maximize", "MaximizeMe", true, func(b *X11Backend, ctx context.Context, title string) error {
+		return b.Maximize(ctx, title)
+	})
+}
+
+func TestX11Backend_Restore(t *testing.T) {
+	t.Run("Window exists", func(t *testing.T) {
+		var events []string
+		var mapped []xproto.Window
+		b := newStubX11Backend(t, true, "RestoreMe")
+		b.conn.(*mockConnection).sendEventCheckedFn = func(p bool, dest xproto.Window, mask uint32, ev string) x11.SendEventCookie {
+			events = append(events, ev)
+			return &mockSendEventCookie{}
+		}
+		b.conn.(*mockConnection).mapWindowCheckedFn = func(w xproto.Window) x11.MapWindowCookie {
+			mapped = append(mapped, w)
+			return &mockMapWindowCookie{}
+		}
+		if err := b.Restore(context.Background(), "RestoreMe"); err != nil {
+			t.Errorf("Restore() unexpected error: %v", err)
+		}
+		if len(events) == 0 {
+			t.Errorf("Restore() did not send event")
+		}
+		if len(mapped) == 0 {
+			t.Errorf("Restore() did not map window")
+		}
+	})
+	t.Run("Window does not exist", func(t *testing.T) {
+		b := newStubX11Backend(t, false, "")
+		err := b.Restore(context.Background(), "Nonexistent")
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Restore() error = %v, want error containing %q", err, "not found")
+		}
+	})
+}
+
+func TestX11Backend_Move(t *testing.T) {
+	t.Run("Window exists", func(t *testing.T) {
+		var cfg []struct {
+			mask   uint16
+			values []uint32
+		}
+		b := newStubX11Backend(t, true, "MoveMe")
+		b.conn.(*mockConnection).configureWindowCheckedFn = func(w xproto.Window, mask uint16, vals []uint32) x11.ConfigureWindowCookie {
+			cfg = append(cfg, struct {
+				mask   uint16
+				values []uint32
+			}{mask, vals})
+			return &mockConfigureWindowCookie{}
+		}
+		if err := b.Move(context.Background(), "MoveMe", 100, 200); err != nil {
+			t.Errorf("Move() unexpected error: %v", err)
+		}
+		if len(cfg) == 0 {
+			t.Errorf("Move() did not configure window")
+		}
+	})
+	t.Run("Window does not exist", func(t *testing.T) {
+		b := newStubX11Backend(t, false, "")
+		err := b.Move(context.Background(), "Nonexistent", 100, 200)
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Move() error = %v, want error containing %q", err, "not found")
+		}
+	})
+}
+
+func TestX11Backend_Resize(t *testing.T) {
+	t.Run("Window exists", func(t *testing.T) {
+		var cfg []struct {
+			mask   uint16
+			values []uint32
+		}
+		b := newStubX11Backend(t, true, "ResizeMe")
+		b.conn.(*mockConnection).configureWindowCheckedFn = func(w xproto.Window, mask uint16, vals []uint32) x11.ConfigureWindowCookie {
+			cfg = append(cfg, struct {
+				mask   uint16
+				values []uint32
+			}{mask, vals})
+			return &mockConfigureWindowCookie{}
+		}
+		if err := b.Resize(context.Background(), "ResizeMe", 1024, 768); err != nil {
+			t.Errorf("Resize() unexpected error: %v", err)
+		}
+		if len(cfg) == 0 {
+			t.Errorf("Resize() did not configure window")
+		}
+	})
+	t.Run("Window does not exist", func(t *testing.T) {
+		b := newStubX11Backend(t, false, "")
+		err := b.Resize(context.Background(), "Nonexistent", 1024, 768)
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Resize() error = %v, want error containing %q", err, "not found")
+		}
+	})
+}
+
+func TestX11Backend_ActiveTitle(t *testing.T) {
+	b := newStubX11Backend(t, true, "Active Window")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetActiveWindow {
+			wid := xproto.Window(50)
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{byte(wid), byte(wid >> 8), byte(wid >> 16), byte(wid >> 24)}}}
+		}
+		if p == b.atomNetWMName {
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 8, Value: []byte("Active Window")}}
+		}
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	title, err := b.ActiveTitle(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveTitle() unexpected error: %v", err)
+	}
+	if title != "Active Window" {
+		t.Errorf("ActiveTitle() = %q, want %q", title, "Active Window")
+	}
+}
+
+func TestX11Backend_ActiveTitle_NoActive(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	title, err := b.ActiveTitle(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveTitle() unexpected error: %v", err)
+	}
+	if title != "" {
+		t.Errorf("ActiveTitle() = %q, want empty", title)
+	}
+}
+
+func TestX11Backend_findByTitle(t *testing.T) {
+	b := newStubX11Backend(t, true, "My Test Window")
+	win, err := b.findByTitle(context.Background(), "My Test Window")
+	if err != nil {
+		t.Errorf("findByTitle(exact) unexpected error: %v", err)
+	}
+	if win != xproto.Window(50) {
+		t.Errorf("findByTitle(exact) = %d, want 50", win)
+	}
+	_, err = b.findByTitle(context.Background(), "Nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("findByTitle(no match) error = %v, want error containing %q", err, "not found")
+	}
+}
+
+func TestX11Backend_windowTitle(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMName {
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 8, Value: []byte("UTF8 Title")}}
+		}
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	if title := b.windowTitle(50); title != "UTF8 Title" {
+		t.Errorf("windowTitle() = %q, want %q", title, "UTF8 Title")
+	}
+}
+
+func TestX11Backend_windowPID(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMPID {
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{42, 0, 0, 0}}}
+		}
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	if pid := b.windowPID(50); pid != 42 {
+		t.Errorf("windowPID() = %d, want 42", pid)
+	}
+}
+
+func TestX11Backend_windowPID_NoPID(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	if pid := b.windowPID(50); pid != 0 {
+		t.Errorf("windowPID() = %d, want 0", pid)
+	}
+}
+
+func TestX11Backend_windowHasDecoration(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomMotifWMHints {
+			data := make([]byte, 20)
+			data[0] = 2 // MwmHintsDecorations flag
+			data[8] = 1 // decorations = 1
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: data}}
+		}
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	if !b.windowHasDecoration(50) {
+		t.Errorf("windowHasDecoration() = false, want true")
+	}
+}
+
+func TestX11Backend_windowHasDecoration_NoDecoration(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getPropertyFn = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomMotifWMHints {
+			data := make([]byte, 20)
+			data[0] = 2 // MwmHintsDecorations flag
+			data[8] = 0 // decorations = 0
+			return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: data}}
+		}
+		return &mockGetPropertyCookie{reply: &xproto.GetPropertyReply{Format: 32, Value: []byte{}}}
+	}
+	if b.windowHasDecoration(50) {
+		t.Errorf("windowHasDecoration() = true, want false")
+	}
+}
+
+func TestX11Backend_windowGeometry(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	b.conn.(*mockConnection).getGeometryFn = func(d xproto.Drawable) x11.GetGeometryCookie {
+		return &mockGetGeometryCookie{reply: &xproto.GetGeometryReply{X: 10, Y: 20, Width: 800, Height: 600}}
+	}
+	b.conn.(*mockConnection).translateCoordinatesFn = func(s, d xproto.Window, x, y int16) x11.TranslateCoordinatesCookie {
+		return &mockTranslateCoordinatesCookie{reply: &xproto.TranslateCoordinatesReply{DstX: 10, DstY: 20}}
+	}
+	x, y, w, h := b.windowGeometry(50)
+	if x != 10 || y != 20 || w != 800 || h != 600 {
+		t.Errorf("windowGeometry() = (%d, %d, %d, %d), want (10, 20, 800, 600)", x, y, w, h)
+	}
+}
+
+func TestX11Backend_Close(t *testing.T) {
+	b := newStubX11Backend(t, false, "")
+	if err := b.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
In https://github.com/nskaggs/perfuncted/pull/23, @nskaggs mentionned that some tests should be added on the X11 side. I'm interested in these as well, but there is a catch: `X11Backend` directly reference a `xgb.Conn`, which is a struct, not an interface, making it difficult to mock. Similarly, the connection object is directly used by `xproto` or `composite` functions that cannot be easily mocked as well.

This makes testing very difficult to says the least, as the code requires a real connection to a X11 server. Some non-null level of refactoring is required before tests can be implemented, and this issue exists in order to discuss how this can be done. 

The simplest solution I can imagine uses one interface (let's call it `x11.Connection` for the sake of this discussion ; the final name might be different). This interface presents all the `xproto` functions required for window/x11.go and screen/x11.go to work. These functions shall return cookie types that are also represented as interfaces (otherwise this could be difficult to create cookies that would answer correctly to a call to `.Reply()` or `.Check()`).

This additional layer of indirection should not have much performance penalty (we're still talking to the X11 socket, and this is order of magnitude slower than an indirection) and it should also help to keep the code nearly identical.

This is as a minimal change as it can be. It leaves apparent all the `.Check()` and `.Reply()` meaning that it is not much of an abstraction. We could go one step further in the abstraction, and make the functions return what is expected by the caller instead of returning cookie types. That would remove a potentially growing list of SomeThinkCookie interfaces and implementations and would require significantly more changes in window/x11.go and screen/x11.go (but not *that* much).

This PR presents only the first abstraction step and implements tests for window/x11.go and screen/x11.go. It also present fixes to some issues that were found during testing. 

The tests were generated by a LLM (Big Fickle, used in an opencode session). I double checked them to verify that they were good enough. In my opinion, they are.

The second abstraction step is clear enough in my mind, and can be worked out quite fast if needed.