### PR TITLE
Feature: x11 window with state

### DIFF
--- a/window/x11.go
+++ b/window/x11.go
@@ -65,6 +65,21 @@ func NewX11Backend(displayName string) (*X11Backend, error) {
 	return b, nil
 }
 
+func (b *X11Backend) activeWindow() (xproto.Window, error) {
+	rep, err := b.conn.GetProperty(false, b.root, b.atomNetActiveWindow,
+		xproto.AtomWindow, 0, 1).Reply()
+	if err != nil {
+		return 0, err
+	}
+	if len(rep.Value) < 4 {
+		return 0, nil
+	}
+	id := xproto.Window(
+		uint32(rep.Value[0]) | uint32(rep.Value[1])<<8 |
+			uint32(rep.Value[2])<<16 | uint32(rep.Value[3])<<24)
+	return id, nil
+}
+
 // windowTitle returns the title of a window, trying _NET_WM_NAME then WM_NAME.
 func (b *X11Backend) windowTitle(win xproto.Window) string {
 	// Try _NET_WM_NAME (UTF-8) first.
@@ -191,16 +206,20 @@ func (b *X11Backend) IterateWindows(ctx context.Context) iter.Seq2[Info, error] 
 					uint32(rep.Value[i*4+2])<<16 | uint32(rep.Value[i*4+3])<<24)
 		}
 
+		// in case of error, activeWindow is not likely to match any id value
+		activeWindow, _ := b.activeWindow()
+
 		for _, id := range ids {
 			x, y, w, h := b.windowGeometry(id)
 			info := Info{
-				ID:    uint64(id),
-				Title: b.windowTitle(id),
-				PID:   b.windowPID(id),
-				X:     x,
-				Y:     y,
-				W:     w,
-				H:     h,
+				ID:     uint64(id),
+				Title:  b.windowTitle(id),
+				PID:    b.windowPID(id),
+				X:      x,
+				Y:      y,
+				W:      w,
+				H:      h,
+				Active: id == activeWindow,
 			}
 			if !yield(info, nil) {
 				return
@@ -285,16 +304,13 @@ func (b *X11Backend) Resize(ctx context.Context, title string, w, h int) error {
 
 // ActiveTitle returns the title of the currently focused window.
 func (b *X11Backend) ActiveTitle(ctx context.Context) (string, error) {
-	rep, err := b.conn.GetProperty(false, b.root, b.atomNetActiveWindow,
-		xproto.AtomWindow, 0, 1).Reply()
+	id, err := b.activeWindow()
 	if err != nil {
 		return "", fmt.Errorf("window/x11: get _NET_ACTIVE_WINDOW: %w", err)
 	}
-	if len(rep.Value) < 4 {
+	if id == 0 {
 		return "", nil
 	}
-	id := xproto.Window(uint32(rep.Value[0]) | uint32(rep.Value[1])<<8 |
-		uint32(rep.Value[2])<<16 | uint32(rep.Value[3])<<24)
 	return b.windowTitle(id), nil
 }
 

--- a/window/x11.go
+++ b/window/x11.go
@@ -80,6 +80,25 @@ func (b *X11Backend) activeWindow() (xproto.Window, error) {
 	return id, nil
 }
 
+func (b *X11Backend) windowState(win xproto.Window) (minimized, maximized bool) {
+	rep, err := b.conn.GetProperty(false, win, b.atomNetWMState,
+		xproto.AtomAtom, 0, 64).Reply()
+	if err != nil || rep.Format != 32 {
+		return
+	}
+	for i := 0; i+3 < len(rep.Value); i += 4 {
+		a := xproto.Atom(uint32(rep.Value[i]) | uint32(rep.Value[i+1])<<8 |
+			uint32(rep.Value[i+2])<<16 | uint32(rep.Value[i+3])<<24)
+		switch a {
+		case b.atomNetWMStateHidden:
+			minimized = true
+		case b.atomNetWMStateMaximizedVert, b.atomNetWMStateMaximizedHorz:
+			maximized = true
+		}
+	}
+	return
+}
+
 // windowTitle returns the title of a window, trying _NET_WM_NAME then WM_NAME.
 func (b *X11Backend) windowTitle(win xproto.Window) string {
 	// Try _NET_WM_NAME (UTF-8) first.
@@ -211,15 +230,18 @@ func (b *X11Backend) IterateWindows(ctx context.Context) iter.Seq2[Info, error] 
 
 		for _, id := range ids {
 			x, y, w, h := b.windowGeometry(id)
+			minimized, maximized := b.windowState(id)
 			info := Info{
-				ID:     uint64(id),
-				Title:  b.windowTitle(id),
-				PID:    b.windowPID(id),
-				X:      x,
-				Y:      y,
-				W:      w,
-				H:      h,
-				Active: id == activeWindow,
+				ID:        uint64(id),
+				Title:     b.windowTitle(id),
+				PID:       b.windowPID(id),
+				X:         x,
+				Y:         y,
+				W:         w,
+				H:         h,
+				Minimized: minimized,
+				Maximized: maximized,
+				Active:    id == activeWindow,
 			}
 			if !yield(info, nil) {
 				return

--- a/window/x11.go
+++ b/window/x11.go
@@ -16,15 +16,19 @@ var _ Manager = (*X11Backend)(nil)
 
 // X11Backend manages windows via EWMH atoms on an X11 or XWayland display.
 type X11Backend struct {
-	conn                x11.Connection
-	root                xproto.Window
-	atomNetClientList   xproto.Atom
-	atomNetActiveWindow xproto.Atom
-	atomNetFrameExtent  xproto.Atom
-	atomNetWMName       xproto.Atom
-	atomNetWMPID        xproto.Atom
-	atomMotifWMHints    xproto.Atom
-	atomUTF8String      xproto.Atom
+	conn                        x11.Connection
+	root                        xproto.Window
+	atomNetClientList           xproto.Atom
+	atomNetActiveWindow         xproto.Atom
+	atomNetFrameExtent          xproto.Atom
+	atomNetWMName               xproto.Atom
+	atomNetWMState              xproto.Atom
+	atomNetWMStateHidden        xproto.Atom
+	atomNetWMStateMaximizedVert xproto.Atom
+	atomNetWMStateMaximizedHorz xproto.Atom
+	atomNetWMPID                xproto.Atom
+	atomMotifWMHints            xproto.Atom
+	atomUTF8String              xproto.Atom
 }
 
 // NewX11Backend connects to the X11 display and interns the EWMH atoms needed
@@ -38,13 +42,17 @@ func NewX11Backend(displayName string) (*X11Backend, error) {
 	b.root = conn.DefaultScreen().Root
 
 	atoms := map[string]*xproto.Atom{
-		"_NET_CLIENT_LIST":   &b.atomNetClientList,
-		"_NET_ACTIVE_WINDOW": &b.atomNetActiveWindow,
-		"_NET_FRAME_EXTENTS": &b.atomNetFrameExtent,
-		"_NET_WM_NAME":       &b.atomNetWMName,
-		"_NET_WM_PID":        &b.atomNetWMPID,
-		"_MOTIF_WM_HINTS":    &b.atomMotifWMHints,
-		"UTF8_STRING":        &b.atomUTF8String,
+		"_NET_CLIENT_LIST":             &b.atomNetClientList,
+		"_NET_ACTIVE_WINDOW":           &b.atomNetActiveWindow,
+		"_NET_FRAME_EXTENTS":           &b.atomNetFrameExtent,
+		"_NET_WM_NAME":                 &b.atomNetWMName,
+		"_NET_WM_STATE":                &b.atomNetWMState,
+		"_NET_WM_STATE_HIDDEN":         &b.atomNetWMStateHidden,
+		"_NET_WM_STATE_MAXIMIZED_VERT": &b.atomNetWMStateMaximizedVert,
+		"_NET_WM_STATE_MAXIMIZED_HORZ": &b.atomNetWMStateMaximizedHorz,
+		"_NET_WM_PID":                  &b.atomNetWMPID,
+		"_MOTIF_WM_HINTS":              &b.atomMotifWMHints,
+		"UTF8_STRING":                  &b.atomUTF8String,
 	}
 	for name, ptr := range atoms {
 		rep, err := b.conn.InternAtom(false, uint16(len(name)), name).Reply()
@@ -233,25 +241,19 @@ func (b *X11Backend) Restore(ctx context.Context, title string) error {
 	if err != nil {
 		return err
 	}
-	stateAtom, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE")), "_NET_WM_STATE").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE: %w", err)
+	data := [5]uint32{
+		0, /* _NET_WM_STATE_REMOVE */
+		uint32(b.atomNetWMStateMaximizedVert),
+		uint32(b.atomNetWMStateMaximizedHorz),
+		1,
+		0,
 	}
-	maxV, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE_MAXIMIZED_VERT")), "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_VERT: %w", err)
-	}
-	maxH, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE_MAXIMIZED_HORZ")), "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_HORZ: %w", err)
-	}
-	data := [5]uint32{0 /* _NET_WM_STATE_REMOVE */, uint32(maxV.Atom), uint32(maxH.Atom), 1, 0}
 	if err := b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
 			Window: win,
-			Type:   stateAtom.Atom,
+			Type:   b.atomNetWMState,
 			Data:   xproto.ClientMessageDataUnionData32New(data[:]),
 		}.Bytes())).Check(); err != nil {
 		return err
@@ -336,7 +338,8 @@ func (b *X11Backend) Minimize(ctx context.Context, title string) error {
 		return err
 	}
 	// Use XIconifyWindow via ChangeProperty with WM_CHANGE_STATE.
-	csAtom, err := b.conn.InternAtom(false, 15, "WM_CHANGE_STATE").Reply()
+	const wmChangeState = "WM_CHANGE_STATE"
+	csAtom, err := b.conn.InternAtom(false, uint16(len(wmChangeState)), wmChangeState).Reply()
 	if err != nil {
 		return fmt.Errorf("window/x11: intern WM_CHANGE_STATE: %w", err)
 	}
@@ -357,25 +360,19 @@ func (b *X11Backend) Maximize(ctx context.Context, title string) error {
 	if err != nil {
 		return err
 	}
-	stateAtom, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE")), "_NET_WM_STATE").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE: %w", err)
+	data := [5]uint32{
+		1, /* _NET_WM_STATE_ADD */
+		uint32(b.atomNetWMStateMaximizedVert),
+		uint32(b.atomNetWMStateMaximizedHorz),
+		1, /* source = application */
+		0,
 	}
-	maxV, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE_MAXIMIZED_VERT")), "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_VERT: %w", err)
-	}
-	maxH, err := b.conn.InternAtom(false, uint16(len("_NET_WM_STATE_MAXIMIZED_HORZ")), "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
-	if err != nil {
-		return fmt.Errorf("window/x11: intern _NET_WM_STATE_MAXIMIZED_HORZ: %w", err)
-	}
-	data := [5]uint32{1 /* _NET_WM_STATE_ADD */, uint32(maxV.Atom), uint32(maxH.Atom), 1 /* source = application */, 0}
 	return b.conn.SendEventChecked(false, b.root,
 		xproto.EventMaskSubstructureRedirect|xproto.EventMaskSubstructureNotify,
 		string(xproto.ClientMessageEvent{
 			Format: 32,
 			Window: win,
-			Type:   stateAtom.Atom,
+			Type:   b.atomNetWMState,
 			Data:   xproto.ClientMessageDataUnionData32New(data[:]),
 		}.Bytes())).Check()
 }

--- a/window/x11_test.go
+++ b/window/x11_test.go
@@ -22,15 +22,19 @@ func newStubX11Backend(t *testing.T, withWindow bool, title string) (*X11Backend
 	t.Helper()
 	conn := &x11.MockConnection{}
 	b := &X11Backend{
-		conn:                conn,
-		root:                1,
-		atomNetClientList:   10,
-		atomNetActiveWindow: 11,
-		atomNetFrameExtent:  12,
-		atomNetWMName:       13,
-		atomNetWMPID:        14,
-		atomMotifWMHints:    15,
-		atomUTF8String:      16,
+		conn:                        conn,
+		root:                        1,
+		atomNetClientList:           10,
+		atomNetActiveWindow:         11,
+		atomNetFrameExtent:          12,
+		atomNetWMName:               13,
+		atomNetWMState:              20,
+		atomNetWMStateHidden:        21,
+		atomNetWMStateMaximizedVert: 22,
+		atomNetWMStateMaximizedHorz: 23,
+		atomNetWMPID:                14,
+		atomMotifWMHints:            15,
+		atomUTF8String:              16,
 	}
 	conn.DefaultScreenFunc = func() *xproto.ScreenInfo {
 		return &xproto.ScreenInfo{Root: b.root, WidthInPixels: 1920, HeightInPixels: 1080}
@@ -395,5 +399,192 @@ func TestX11Backend_Close(t *testing.T) {
 	b, _ := newStubX11Backend(t, false, "")
 	if err := b.Close(); err != nil {
 		t.Errorf("Close() unexpected error: %v", err)
+	}
+}
+
+func TestX11Backend_activeWindow(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	// Test with active window
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetActiveWindow {
+			wid := xproto.Window(50)
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{byte(wid), byte(wid >> 8), byte(wid >> 16), byte(wid >> 24)}})
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	win, err := b.activeWindow()
+	if err != nil {
+		t.Fatalf("activeWindow() unexpected error: %v", err)
+	}
+	if win != xproto.Window(50) {
+		t.Errorf("activeWindow() = %d, want 50", win)
+	}
+}
+
+func TestX11Backend_activeWindow_NoActive(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	win, err := b.activeWindow()
+	if err != nil {
+		t.Fatalf("activeWindow() unexpected error: %v", err)
+	}
+	if win != 0 {
+		t.Errorf("activeWindow() = %d, want 0", win)
+	}
+}
+
+func TestX11Backend_activeWindow_Error(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		return x11.NewMockGetPropertyCookieError(fmt.Errorf("connection error"))
+	}
+	_, err := b.activeWindow()
+	if err == nil {
+		t.Fatal("activeWindow() expected error, got nil")
+	}
+}
+
+func TestX11Backend_windowState_Minimized(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMState {
+			// Return _NET_WM_STATE_HIDDEN in the state
+			atomBytes := []byte{
+				byte(b.atomNetWMStateHidden), byte(b.atomNetWMStateHidden >> 8),
+				byte(b.atomNetWMStateHidden >> 16), byte(b.atomNetWMStateHidden >> 24),
+			}
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: atomBytes})
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	minimized, maximized := b.windowState(50)
+	if !minimized {
+		t.Errorf("windowState() minimized = false, want true")
+	}
+	if maximized {
+		t.Errorf("windowState() maximized = true, want false")
+	}
+}
+
+func TestX11Backend_windowState_Maximized(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMState {
+			// Return both maximized vert and horz (8 bytes = 2 atoms * 4 bytes each)
+			atomBytes := make([]byte, 8)
+			// _NET_WM_STATE_MAXIMIZED_VERT
+			atomBytes[0] = byte(b.atomNetWMStateMaximizedVert)
+			atomBytes[1] = byte(b.atomNetWMStateMaximizedVert >> 8)
+			atomBytes[2] = byte(b.atomNetWMStateMaximizedVert >> 16)
+			atomBytes[3] = byte(b.atomNetWMStateMaximizedVert >> 24)
+			// _NET_WM_STATE_MAXIMIZED_HORZ
+			atomBytes[4] = byte(b.atomNetWMStateMaximizedHorz)
+			atomBytes[5] = byte(b.atomNetWMStateMaximizedHorz >> 8)
+			atomBytes[6] = byte(b.atomNetWMStateMaximizedHorz >> 16)
+			atomBytes[7] = byte(b.atomNetWMStateMaximizedHorz >> 24)
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: atomBytes})
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	minimized, maximized := b.windowState(50)
+	if minimized {
+		t.Errorf("windowState() minimized = true, want false")
+	}
+	if !maximized {
+		t.Errorf("windowState() maximized = false, want true")
+	}
+}
+
+func TestX11Backend_windowState_Both(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMState {
+			// Return hidden, maximized vert, and maximized horz (12 bytes = 3 atoms * 4 bytes each)
+			atomBytes := make([]byte, 12)
+			// _NET_WM_STATE_HIDDEN
+			atomBytes[0] = byte(b.atomNetWMStateHidden)
+			atomBytes[1] = byte(b.atomNetWMStateHidden >> 8)
+			atomBytes[2] = byte(b.atomNetWMStateHidden >> 16)
+			atomBytes[3] = byte(b.atomNetWMStateHidden >> 24)
+			// _NET_WM_STATE_MAXIMIZED_VERT
+			atomBytes[4] = byte(b.atomNetWMStateMaximizedVert)
+			atomBytes[5] = byte(b.atomNetWMStateMaximizedVert >> 8)
+			atomBytes[6] = byte(b.atomNetWMStateMaximizedVert >> 16)
+			atomBytes[7] = byte(b.atomNetWMStateMaximizedVert >> 24)
+			// _NET_WM_STATE_MAXIMIZED_HORZ
+			atomBytes[8] = byte(b.atomNetWMStateMaximizedHorz)
+			atomBytes[9] = byte(b.atomNetWMStateMaximizedHorz >> 8)
+			atomBytes[10] = byte(b.atomNetWMStateMaximizedHorz >> 16)
+			atomBytes[11] = byte(b.atomNetWMStateMaximizedHorz >> 24)
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: atomBytes})
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	minimized, maximized := b.windowState(50)
+	if !minimized {
+		t.Errorf("windowState() minimized = false, want true")
+	}
+	if !maximized {
+		t.Errorf("windowState() maximized = false, want true")
+	}
+}
+
+func TestX11Backend_windowState_Error(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMState {
+			return x11.NewMockGetPropertyCookieError(fmt.Errorf("connection error"))
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	minimized, maximized := b.windowState(50)
+	if minimized || maximized {
+		t.Errorf("windowState() with error should return false, false, got %v, %v", minimized, maximized)
+	}
+}
+
+func TestX11Backend_IterateWindows_MinimizedMaximized(t *testing.T) {
+	b, conn := newStubX11Backend(t, true, "Test Window")
+	// Override getPropertyFn to also handle atomNetWMState
+	origFn := conn.GetPropertyFunc
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, t xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == b.atomNetWMState {
+			// Return both hidden and maximized (12 bytes = 3 atoms * 4 bytes each)
+			atomBytes := make([]byte, 12)
+			// _NET_WM_STATE_HIDDEN
+			atomBytes[0] = byte(b.atomNetWMStateHidden)
+			atomBytes[1] = byte(b.atomNetWMStateHidden >> 8)
+			atomBytes[2] = byte(b.atomNetWMStateHidden >> 16)
+			atomBytes[3] = byte(b.atomNetWMStateHidden >> 24)
+			// _NET_WM_STATE_MAXIMIZED_VERT
+			atomBytes[4] = byte(b.atomNetWMStateMaximizedVert)
+			atomBytes[5] = byte(b.atomNetWMStateMaximizedVert >> 8)
+			atomBytes[6] = byte(b.atomNetWMStateMaximizedVert >> 16)
+			atomBytes[7] = byte(b.atomNetWMStateMaximizedVert >> 24)
+			// _NET_WM_STATE_MAXIMIZED_HORZ
+			atomBytes[8] = byte(b.atomNetWMStateMaximizedHorz)
+			atomBytes[9] = byte(b.atomNetWMStateMaximizedHorz >> 8)
+			atomBytes[10] = byte(b.atomNetWMStateMaximizedHorz >> 16)
+			atomBytes[11] = byte(b.atomNetWMStateMaximizedHorz >> 24)
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: atomBytes})
+		}
+		// Call original function for other properties
+		return origFn(d, w, p, t, lo, ll)
+	}
+	ctx := context.Background()
+	var found Info
+	for info, err := range b.IterateWindows(ctx) {
+		if err != nil {
+			t.Fatalf("IterateWindows() error: %v", err)
+		}
+		found = info
+	}
+	if !found.Minimized {
+		t.Errorf("IterateWindows() Minimized = false, want true")
+	}
+	if !found.Maximized {
+		t.Errorf("IterateWindows() Maximized = false, want true")
 	}
 }


### PR DESCRIPTION
This PR adds support to get some window state in X11. These states include:

* is the window minimized?
* is the window maximized?
* is this the active window?

These information can be retrieved from the X11 library.

In order to do this properly, some X11 atoms are now fetched during the X11Backend construction (commit: `feat(x11): add new X11 atom types used by the X11 screen manager`). Some new private functions have been added to the X11Backend (commits: `feat(x11): add X11Backend.activeWindow() and use it when necessary`, `feat(x11): add X11Backend.windowState() to get the X11 window state`). And finally, some tests have been modified and new tests have been implemented to verify the behavior of these new functions (commit: `feat(x11): add more unit test for the X11 window backend`).