### PR TITLE
api: clean up public surface - remove *Context methods, consolidate WaitFor*

### DIFF
--- a/bundle_input_test.go
+++ b/bundle_input_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/nskaggs/perfuncted/pftest"
 )
 
-func TestPerfunctedTypeFast_ClipboardPath(t *testing.T) {
+func TestPerfunctedPaste_ClipboardPath(t *testing.T) {
 	inp := &pftest.Inputter{}
 	cb := &pftest.Clipboard{}
 	pf := pftest.New(nil, inp, nil, cb)
 
-	// Perfuncted.TypeFast uses Clipboard.PasteWithInput internally.
-	if err := pf.TypeFast("hello world"); err != nil {
-		t.Fatalf("TypeFast: %v", err)
+	// Perfuncted.Paste uses clipboard+PasteCombo when a clipboard is available.
+	if err := pf.Paste("hello world"); err != nil {
+		t.Fatalf("Paste: %v", err)
 	}
 
 	// Verify clipboard was set.
@@ -36,13 +36,13 @@ func TestPerfunctedTypeFast_ClipboardPath(t *testing.T) {
 	}
 }
 
-func TestPerfunctedTypeFast_FallbackToType(t *testing.T) {
-	// When clipboard is nil, TypeFast should fall back to Type.
+func TestPerfunctedPaste_FallbackToType(t *testing.T) {
+	// When clipboard is nil, Paste should fall back to Type.
 	inp := &pftest.Inputter{}
 	pf := pftest.New(nil, inp, nil, nil)
 
-	if err := pf.TypeFast("abc"); err != nil {
-		t.Fatalf("TypeFast: %v", err)
+	if err := pf.Paste("abc"); err != nil {
+		t.Fatalf("Paste: %v", err)
 	}
 
 	// Should have called Type with the full string.
@@ -58,14 +58,13 @@ func TestPerfunctedTypeFast_FallbackToType(t *testing.T) {
 	}
 }
 
-func TestPerfunctedTypeFast_ClipboardSetFails(t *testing.T) {
-	// When clipboard.Set fails, Perfuncted.TypeFast returns the error
-	// (no fallback — that's InputBundle.TypeFast's job).
+func TestPerfunctedPaste_ClipboardSetFails(t *testing.T) {
+	// When clipboard.Set fails, Perfuncted.Paste returns the error.
 	inp := &pftest.Inputter{}
 	cb := &pftest.Clipboard{SetErr: context.DeadlineExceeded}
 	pf := pftest.New(nil, inp, nil, cb)
 
-	err := pf.TypeFast("fallback")
+	err := pf.Paste("fallback")
 	if err == nil {
 		t.Fatal("expected error when clipboard.Set fails")
 	}

--- a/bundle_screen.go
+++ b/bundle_screen.go
@@ -40,7 +40,7 @@ func (s ScreenBundle) traceAction(msg string) {
 	s.tracer.Tracef("screen", "%s", msg)
 }
 
-func (s ScreenBundle) GrabHashContext(ctx context.Context, rect image.Rectangle) (uint32, error) {
+func (s ScreenBundle) grabHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
 	s.traceAction(fmt.Sprintf("grab-hash rect=%s", rect))
 	if err := s.checkAvailable(); err != nil {
 		return 0, err
@@ -51,7 +51,7 @@ func (s ScreenBundle) GrabHashContext(ctx context.Context, rect image.Rectangle)
 	return find.GrabHash(ctx, s.Screenshotter, rect, nil)
 }
 
-func (s ScreenBundle) GrabContext(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+func (s ScreenBundle) grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
 	s.traceAction(fmt.Sprintf("grab rect=%s", rect))
 	if err := s.checkAvailable(); err != nil {
 		return nil, err
@@ -62,9 +62,10 @@ func (s ScreenBundle) GrabContext(ctx context.Context, rect image.Rectangle) (im
 	return s.Screenshotter.Grab(ctx, rect)
 }
 
-func (s ScreenBundle) CaptureRegionContext(ctx context.Context, rect image.Rectangle, path string) error {
+// CaptureRegion captures the given screen region and saves it as a PNG file at path.
+func (s ScreenBundle) CaptureRegion(rect image.Rectangle, path string) error {
 	s.traceAction(fmt.Sprintf("capture-region rect=%s path=%q", rect, path))
-	img, err := s.GrabContext(ctx, rect)
+	img, err := s.grab(context.Background(), rect)
 	if err != nil {
 		return err
 	}
@@ -76,19 +77,21 @@ func (s ScreenBundle) CaptureRegionContext(ctx context.Context, rect image.Recta
 	return png.Encode(f, img)
 }
 
-func (s ScreenBundle) GetPixelContext(ctx context.Context, x, y int) (color.RGBA, error) {
+// GetPixel returns the colour of the pixel at (x, y).
+func (s ScreenBundle) GetPixel(x, y int) (color.RGBA, error) {
 	s.traceAction(fmt.Sprintf("get-pixel x=%d y=%d", x, y))
 	if err := s.checkAvailable(); err != nil {
 		return color.RGBA{}, err
 	}
-	c, err := find.FirstPixel(ctx, s.Screenshotter, image.Rect(x, y, x+1, y+1))
+	c, err := find.FirstPixel(context.Background(), s.Screenshotter, image.Rect(x, y, x+1, y+1))
 	if err != nil {
 		return color.RGBA{}, err
 	}
 	return c, nil
 }
 
-func (s ScreenBundle) GetMultiplePixelsContext(ctx context.Context, points []image.Point) ([]color.RGBA, error) {
+// GetMultiplePixels returns the colours of all given points in a single grab.
+func (s ScreenBundle) GetMultiplePixels(points []image.Point) ([]color.RGBA, error) {
 	s.traceAction(fmt.Sprintf("get-multiple-pixels count=%d", len(points)))
 	if err := s.checkAvailable(); err != nil {
 		return nil, err
@@ -114,7 +117,7 @@ func (s ScreenBundle) GetMultiplePixelsContext(ctx context.Context, points []ima
 		}
 	}
 	bounds := image.Rect(minX, minY, maxX+1, maxY+1)
-	img, err := s.GrabContext(ctx, bounds)
+	img, err := s.grab(context.Background(), bounds)
 	if err != nil {
 		return nil, err
 	}
@@ -125,32 +128,8 @@ func (s ScreenBundle) GetMultiplePixelsContext(ctx context.Context, points []ima
 	return out, nil
 }
 
-// pixelToScreen currently returns the rectangle's Min point. If a real
-// coordinate conversion is required by some backends, implement it here.
-// TODO: remove this helper if unused or implement proper conversion.
-func (s ScreenBundle) WaitForAnyChangeContext(ctx context.Context, timeout time.Duration) error {
-	s.traceAction(fmt.Sprintf("wait-for-any-change timeout=%s", timeout))
-	if err := s.checkAvailable(); err != nil {
-		return err
-	}
-	cctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	_, _ = s.WaitForVisibleChangeContext(cctx, image.Rectangle{}, 0, 1)
-	return nil
-}
-
-func (s ScreenBundle) WaitForStableOrTimeoutContext(ctx context.Context, rect image.Rectangle, timeout time.Duration) error {
-	s.traceAction(fmt.Sprintf("wait-for-stable-or-timeout rect=%s timeout=%s", rect, timeout))
-	if err := s.checkAvailable(); err != nil {
-		return err
-	}
-	cctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	_, _ = find.WaitForNoChange(cctx, s.Screenshotter, rect, 3, 0, nil)
-	return nil
-}
-
-func (s ScreenBundle) WaitForFnContext(ctx context.Context, rect image.Rectangle, fn func(image.Image) bool, poll time.Duration) (image.Image, error) {
+// WaitForFn polls rect every poll interval until fn returns true, or ctx is cancelled.
+func (s ScreenBundle) WaitForFn(ctx context.Context, rect image.Rectangle, fn func(image.Image) bool, poll time.Duration) (image.Image, error) {
 	s.traceAction(fmt.Sprintf("wait-for-fn rect=%s poll=%s", rect, poll))
 	if err := s.checkAvailable(); err != nil {
 		return nil, err
@@ -158,39 +137,14 @@ func (s ScreenBundle) WaitForFnContext(ctx context.Context, rect image.Rectangle
 	return find.WaitForFn(ctx, s.Screenshotter, rect, fn, poll)
 }
 
-func (s ScreenBundle) WaitForVisibleChangeContext(ctx context.Context, rect image.Rectangle, poll time.Duration, stable int) (uint32, error) {
-	s.traceAction(fmt.Sprintf("wait-for-visible-change rect=%s poll=%s stable=%d", rect, poll, stable))
-	if err := s.checkAvailable(); err != nil {
-		return 0, err
-	}
-	initial, err := s.GrabHashContext(ctx, rect)
-	if err != nil {
-		return 0, err
-	}
-	h, err := find.WaitForChange(ctx, s.Screenshotter, rect, initial, poll, nil)
-	if err != nil {
-		return 0, err
-	}
-	if stable > 1 {
-		return find.WaitForNoChange(ctx, s.Screenshotter, rect, stable, poll, nil)
-	}
-	return h, nil
-}
-
-func (s ScreenBundle) WaitForStableContext(ctx context.Context, rect image.Rectangle, stableN int, poll time.Duration) (uint32, error) {
-	s.traceAction(fmt.Sprintf("wait-for-stable rect=%s stable=%d poll=%s", rect, stableN, poll))
-	if err := s.checkAvailable(); err != nil {
-		return 0, err
-	}
-	return find.WaitForNoChange(ctx, s.Screenshotter, rect, stableN, poll, nil)
-}
-
-func (s ScreenBundle) WaitForSettleContext(ctx context.Context, rect image.Rectangle, action func(), stable int, poll time.Duration) (uint32, error) {
+// WaitForSettle grabs a hash before calling action, waits for the region to
+// change, then waits for it to stabilise over stable consecutive polls.
+func (s ScreenBundle) WaitForSettle(ctx context.Context, rect image.Rectangle, action func(), stable int, poll time.Duration) (uint32, error) {
 	s.traceAction(fmt.Sprintf("wait-for-settle rect=%s stable=%d poll=%s", rect, stable, poll))
 	if err := s.checkAvailable(); err != nil {
 		return 0, err
 	}
-	before, err := s.GrabHashContext(ctx, rect)
+	before, err := s.grabHash(ctx, rect)
 	if err != nil {
 		return 0, err
 	}
@@ -201,23 +155,18 @@ func (s ScreenBundle) WaitForSettleContext(ctx context.Context, rect image.Recta
 	return find.WaitForNoChange(ctx, s.Screenshotter, rect, stable, poll, nil)
 }
 
-func (s ScreenBundle) FindColorContext(ctx context.Context, rect image.Rectangle, target color.RGBA, tolerance int) (image.Point, error) {
+// FindColor searches rect for the first pixel matching target within tolerance.
+func (s ScreenBundle) FindColor(rect image.Rectangle, target color.RGBA, tolerance int) (image.Point, error) {
 	s.traceAction(fmt.Sprintf("find-color rect=%s tolerance=%d", rect, tolerance))
 	if err := s.checkAvailable(); err != nil {
 		return image.Point{}, err
 	}
-	return find.FindColor(ctx, s.Screenshotter, rect, target, tolerance)
+	return find.FindColor(context.Background(), s.Screenshotter, rect, target, tolerance)
 }
 
-func (s ScreenBundle) WaitForNoChangeContext(ctx context.Context, rect image.Rectangle, stable int, poll time.Duration) (uint32, error) {
-	s.traceAction(fmt.Sprintf("wait-for-no-change rect=%s stable=%d poll=%s", rect, stable, poll))
-	if err := s.checkAvailable(); err != nil {
-		return 0, err
-	}
-	return find.WaitForNoChange(ctx, s.Screenshotter, rect, stable, poll, nil)
-}
-
-func (s ScreenBundle) WaitForChangeContext(ctx context.Context, rect image.Rectangle, initial uint32, poll time.Duration) (uint32, error) {
+// WaitForChange polls rect every poll interval until its hash differs from
+// initial, or ctx is cancelled.
+func (s ScreenBundle) WaitForChange(ctx context.Context, rect image.Rectangle, initial uint32, poll time.Duration) (uint32, error) {
 	s.traceAction(fmt.Sprintf("wait-for-change rect=%s initial=%08x poll=%s", rect, initial, poll))
 	if err := s.checkAvailable(); err != nil {
 		return 0, err
@@ -225,7 +174,9 @@ func (s ScreenBundle) WaitForChangeContext(ctx context.Context, rect image.Recta
 	return find.WaitForChange(ctx, s.Screenshotter, rect, initial, poll, nil)
 }
 
-func (s ScreenBundle) WaitForContext(ctx context.Context, rect image.Rectangle, want uint32, poll time.Duration) (uint32, error) {
+// WaitFor polls rect every poll interval until its hash equals want, or ctx
+// is cancelled.
+func (s ScreenBundle) WaitFor(ctx context.Context, rect image.Rectangle, want uint32, poll time.Duration) (uint32, error) {
 	s.traceAction(fmt.Sprintf("wait-for rect=%s want=%08x poll=%s", rect, want, poll))
 	if err := s.checkAvailable(); err != nil {
 		return 0, err
@@ -233,7 +184,9 @@ func (s ScreenBundle) WaitForContext(ctx context.Context, rect image.Rectangle, 
 	return find.WaitFor(ctx, s.Screenshotter, rect, want, poll, nil)
 }
 
-func (s ScreenBundle) ScanForContext(ctx context.Context, rects []image.Rectangle, wants []uint32, poll time.Duration) (find.Result, error) {
+// ScanFor polls multiple regions in round-robin until one matches its
+// expected hash, or ctx is cancelled.
+func (s ScreenBundle) ScanFor(ctx context.Context, rects []image.Rectangle, wants []uint32, poll time.Duration) (find.Result, error) {
 	s.traceAction(fmt.Sprintf("scan-for rects=%d wants=%d poll=%s", len(rects), len(wants), poll))
 	if err := s.checkAvailable(); err != nil {
 		return find.Result{}, err
@@ -241,10 +194,11 @@ func (s ScreenBundle) ScanForContext(ctx context.Context, rects []image.Rectangl
 	return find.ScanFor(ctx, s.Screenshotter, rects, wants, poll, nil)
 }
 
-func (s ScreenBundle) ResolutionContext(ctx context.Context) (int, int, error) {
+// Resolution returns the current screen dimensions.
+func (s ScreenBundle) Resolution() (int, int, error) {
 	s.traceAction("resolution")
 	if err := s.checkAvailable(); err != nil {
 		return 0, 0, err
 	}
-	return screen.ResolutionWithContext(ctx, s.Screenshotter)
+	return screen.ResolutionWithContext(context.Background(), s.Screenshotter)
 }

--- a/bundle_window.go
+++ b/bundle_window.go
@@ -3,6 +3,7 @@ package perfuncted
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/nskaggs/perfuncted/internal/util"
 	"github.com/nskaggs/perfuncted/window"
@@ -34,66 +35,95 @@ func (w WindowBundle) traceAction(msg string) {
 	w.tracer.Tracef("window", "%s", msg)
 }
 
-func (w WindowBundle) ActivateContext(ctx context.Context, pattern string) error {
+// Activate raises and focuses the window matching pattern.
+func (w WindowBundle) Activate(pattern string) error {
 	w.traceAction(fmt.Sprintf("activate pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.Activate(ctx, pattern)
+	return w.Manager.Activate(context.Background(), pattern)
 }
 
-func (w WindowBundle) ActiveTitleContext(ctx context.Context) (string, error) {
+// ActiveTitle returns the title of the currently focused window.
+func (w WindowBundle) ActiveTitle() (string, error) {
 	w.traceAction("active-title")
 	if err := w.checkAvailable(); err != nil {
 		return "", err
 	}
-	return w.Manager.ActiveTitle(ctx)
+	return w.Manager.ActiveTitle(context.Background())
 }
 
-func (w WindowBundle) CloseWindowContext(ctx context.Context, pattern string) error {
+// CloseWindow closes the window matching pattern.
+func (w WindowBundle) CloseWindow(pattern string) error {
 	w.traceAction(fmt.Sprintf("close-window pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.CloseWindow(ctx, pattern)
+	return w.Manager.CloseWindow(context.Background(), pattern)
 }
 
-func (w WindowBundle) ResizeContext(ctx context.Context, pattern string, width, height int) error {
+// Resize sets the dimensions of the window matching pattern.
+func (w WindowBundle) Resize(pattern string, width, height int) error {
 	w.traceAction(fmt.Sprintf("resize pattern=%q width=%d height=%d", pattern, width, height))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.Resize(ctx, pattern, width, height)
+	return w.Manager.Resize(context.Background(), pattern, width, height)
 }
 
-func (w WindowBundle) MinimizeContext(ctx context.Context, pattern string) error {
+// Minimize minimises the window matching pattern.
+func (w WindowBundle) Minimize(pattern string) error {
 	w.traceAction(fmt.Sprintf("minimize pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.Minimize(ctx, pattern)
+	return w.Manager.Minimize(context.Background(), pattern)
 }
 
-func (w WindowBundle) MaximizeContext(ctx context.Context, pattern string) error {
+// Maximize maximises the window matching pattern.
+func (w WindowBundle) Maximize(pattern string) error {
 	w.traceAction(fmt.Sprintf("maximize pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.Maximize(ctx, pattern)
+	return w.Manager.Maximize(context.Background(), pattern)
 }
 
-func (w WindowBundle) RestoreContext(ctx context.Context, pattern string) error {
+// Restore restores the window matching pattern to its previous size.
+func (w WindowBundle) Restore(pattern string) error {
 	w.traceAction(fmt.Sprintf("restore pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return err
 	}
-	return w.Manager.Restore(ctx, pattern)
+	return w.Manager.Restore(context.Background(), pattern)
 }
 
-func (w WindowBundle) FindByTitleContext(ctx context.Context, pattern string) (window.Info, error) {
+// FindByTitle returns the first window whose title contains pattern
+// (case-insensitive).
+func (w WindowBundle) FindByTitle(pattern string) (window.Info, error) {
 	w.traceAction(fmt.Sprintf("find-by-title pattern=%q", pattern))
 	if err := w.checkAvailable(); err != nil {
 		return window.Info{}, err
 	}
-	return window.FindByTitle(ctx, w.Manager, pattern)
+	return window.FindByTitle(context.Background(), w.Manager, pattern)
+}
+
+// WaitForWindow polls until a window matching pattern is found, or ctx is
+// cancelled.
+func (w WindowBundle) WaitForWindow(ctx context.Context, pattern string, poll time.Duration) (window.Info, error) {
+	w.traceAction(fmt.Sprintf("wait-for-window pattern=%q poll=%s", pattern, poll))
+	if err := w.checkAvailable(); err != nil {
+		return window.Info{}, err
+	}
+	return window.WaitFor(ctx, w.Manager, pattern, poll)
+}
+
+// WaitForClose polls until no window matches pattern (window is gone), or ctx
+// is cancelled.
+func (w WindowBundle) WaitForClose(ctx context.Context, pattern string, poll time.Duration) error {
+	w.traceAction(fmt.Sprintf("wait-for-close pattern=%q poll=%s", pattern, poll))
+	if err := w.checkAvailable(); err != nil {
+		return err
+	}
+	return window.WaitForClose(ctx, w.Manager, pattern, poll)
 }

--- a/cmd/pf/autogen_gen.go
+++ b/cmd/pf/autogen_gen.go
@@ -2,12 +2,63 @@
 package main
 
 import (
+	"fmt"
 	"github.com/nskaggs/perfuncted"
 	"github.com/spf13/cobra"
 )
 
 func autogenScreenCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cobra.Command {
 	cmds := []*cobra.Command{}
+
+	// capture-region: wrapper for perfuncted.CaptureRegion
+	var cmd_screen_capture_region_rect string
+	var cmd_screen_capture_region_path string
+	cmd_screen_capture_region := &cobra.Command{
+		Use:   "capture-region",
+		Short: "Auto-generated wrapper for perfuncted.CaptureRegion",
+		RunE: func(_ *cobra.Command, args []string) error {
+			pf, err := openPF()
+			if err != nil {
+				return err
+			}
+			defer pf.Close()
+			r_0, err := parseRect(cmd_screen_capture_region_rect)
+			if err != nil {
+				return err
+			}
+			// flag cmd_screen_capture_region_path (string)
+			if err := pf.Screen.CaptureRegion(r_0, cmd_screen_capture_region_path); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd_screen_capture_region.Flags().StringVar(&cmd_screen_capture_region_rect, "rect", "0,0,1920,1080", "x0,y0,x1,y1")
+	cmd_screen_capture_region.Flags().StringVar(&cmd_screen_capture_region_path, "path", "", "path")
+
+	cmds = append(cmds, cmd_screen_capture_region)
+
+	// resolution: wrapper for perfuncted.Resolution
+
+	cmd_screen_resolution := &cobra.Command{
+		Use:   "resolution",
+		Short: "Auto-generated wrapper for perfuncted.Resolution",
+		RunE: func(_ *cobra.Command, args []string) error {
+			pf, err := openPF()
+			if err != nil {
+				return err
+			}
+			defer pf.Close()
+			w, h, err := pf.Screen.Resolution()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%dx%d\n", w, h)
+			return nil
+		},
+	}
+
+	cmds = append(cmds, cmd_screen_resolution)
 	return cmds
 }
 func autogenInputCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cobra.Command {
@@ -16,6 +67,28 @@ func autogenInputCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cobr
 }
 func autogenWindowCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cobra.Command {
 	cmds := []*cobra.Command{}
+
+	// restore: wrapper for perfuncted.Restore
+	var cmd_window_restore_pattern string
+	cmd_window_restore := &cobra.Command{
+		Use:   "restore",
+		Short: "Auto-generated wrapper for perfuncted.Restore",
+		RunE: func(_ *cobra.Command, args []string) error {
+			pf, err := openPF()
+			if err != nil {
+				return err
+			}
+			defer pf.Close()
+			// flag cmd_window_restore_pattern (string)
+			if err := pf.Window.Restore(cmd_window_restore_pattern); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd_window_restore.Flags().StringVar(&cmd_window_restore_pattern, "pattern", "", "pattern")
+
+	cmds = append(cmds, cmd_window_restore)
 	return cmds
 }
 func autogenClipboardCommands(openPF func() (*perfuncted.Perfuncted, error)) []*cobra.Command {

--- a/cmd/pf/root.go
+++ b/cmd/pf/root.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/png"
 	"io"
 	"os"
 	"os/signal"
@@ -24,6 +23,7 @@ import (
 	"github.com/spf13/cobra/doc"
 
 	"github.com/nskaggs/perfuncted"
+	"github.com/nskaggs/perfuncted/find"
 	"github.com/nskaggs/perfuncted/input"
 	"github.com/nskaggs/perfuncted/internal/compositor"
 	"github.com/nskaggs/perfuncted/screen"
@@ -337,20 +337,11 @@ func screenCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			img, err := pf.Screen.GrabContext(context.Background(), r)
-			if err != nil {
-				return err
-			}
 			out := outFlag
 			if out == "" {
 				out = "/tmp/pf-grab.png"
 			}
-			f, err := os.Create(out)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			if err := png.Encode(f, img); err != nil {
+			if err := pf.Screen.CaptureRegion(r, out); err != nil {
 				return err
 			}
 			fmt.Println(out)
@@ -373,7 +364,7 @@ func screenCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			h, err := pf.Screen.GrabHashContext(context.Background(), r)
+			h, err := pf.Screen.GrabRegionHash(context.Background(), r)
 			if err != nil {
 				return err
 			}
@@ -393,7 +384,7 @@ func screenCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			c, err := pf.Screen.GetPixelContext(context.Background(), px, py)
+			c, err := pf.Screen.GetPixel(px, py)
 			if err != nil {
 				return err
 			}
@@ -469,7 +460,7 @@ Runs until --duration expires or Ctrl+C.`,
 					return nil
 				default:
 				}
-				h, err := pf.Screen.GrabHashContext(context.Background(), r)
+				h, err := pf.Screen.GrabRegionHash(context.Background(), r)
 				if err != nil {
 					return err
 				}
@@ -512,7 +503,7 @@ Runs until --duration expires or Ctrl+C.`,
 				return err
 			}
 			defer pf.Close()
-			w, h, err := pf.Screen.ResolutionContext(context.Background())
+			w, h, err := pf.Screen.Resolution()
 			if err != nil {
 				return err
 			}
@@ -886,7 +877,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			if err := pf.Window.ActivateContext(context.Background(), args[0]); err != nil {
+			if err := pf.Window.Activate(args[0]); err != nil {
 				return err
 			}
 			fmt.Printf("activated: %s\n", args[0])
@@ -903,7 +894,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			t, err := pf.Window.ActiveTitleContext(context.Background())
+			t, err := pf.Window.ActiveTitle()
 			if err != nil {
 				return err
 			}
@@ -946,7 +937,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			if err := pf.Window.ResizeContext(context.Background(), rsTitle, rsW, rsH); err != nil {
+			if err := pf.Window.Resize(rsTitle, rsW, rsH); err != nil {
 				return err
 			}
 			fmt.Printf("resized %q to %dx%d\n", rsTitle, rsW, rsH)
@@ -971,7 +962,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			info, err := pf.Window.FindByTitleContext(context.Background(), args[0])
+			info, err := pf.Window.FindByTitle(args[0])
 			if err != nil {
 				return err
 			}
@@ -992,7 +983,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			info, err := pf.Window.FindByTitleContext(context.Background(), args[0])
+			info, err := pf.Window.FindByTitle(args[0])
 			if err != nil {
 				return err
 			}
@@ -1012,7 +1003,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			_, err = pf.Window.FindByTitleContext(context.Background(), args[0])
+			_, err = pf.Window.FindByTitle(args[0])
 			if err == nil {
 				fmt.Println("true")
 			} else {
@@ -1034,7 +1025,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			if err := pf.Window.CloseWindowContext(context.Background(), args[0]); err != nil {
+			if err := pf.Window.CloseWindow(args[0]); err != nil {
 				return err
 			}
 			fmt.Printf("closed: %s\n", args[0])
@@ -1052,7 +1043,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			if err := pf.Window.MinimizeContext(context.Background(), args[0]); err != nil {
+			if err := pf.Window.Minimize(args[0]); err != nil {
 				return err
 			}
 			fmt.Printf("minimized: %s\n", args[0])
@@ -1070,7 +1061,7 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 				return err
 			}
 			defer pf.Close()
-			if err := pf.Window.MaximizeContext(context.Background(), args[0]); err != nil {
+			if err := pf.Window.Maximize(args[0]); err != nil {
 				return err
 			}
 			fmt.Printf("maximized: %s\n", args[0])
@@ -1137,7 +1128,7 @@ func findCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			h, err := pf.Screen.WaitForContext(ctx, r, want, poll)
+			h, err := pf.Screen.WaitFor(ctx, r, want, poll)
 			if err != nil {
 				return err
 			}
@@ -1166,7 +1157,7 @@ func findCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 			}
 			var initial uint32
 			if captureInitial {
-				if initial, err = pf.Screen.GrabHashContext(context.Background(), r); err != nil {
+				if initial, err = pf.Screen.GrabRegionHash(context.Background(), r); err != nil {
 					return err
 				}
 			} else {
@@ -1184,7 +1175,7 @@ func findCmd(openPF func() (*perfuncted.Perfuncted, error)) *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			h, err := pf.Screen.WaitForChangeContext(ctx, r, initial, poll)
+			h, err := pf.Screen.WaitForChange(ctx, r, initial, poll)
 			if err != nil {
 				return err
 			}
@@ -1227,7 +1218,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			h, err := pf.Screen.WaitForNoChangeContext(ctx, r, stableCount, poll)
+			h, err := find.WaitForNoChange(ctx, pf.Screen.Screenshotter, r, stableCount, poll, nil)
 			if err != nil {
 				return err
 			}
@@ -1271,7 +1262,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			res, err := pf.Screen.ScanForContext(ctx, rects, wants, poll)
+			res, err := pf.Screen.ScanFor(ctx, rects, wants, poll)
 			if err != nil {
 				return err
 			}
@@ -1314,9 +1305,19 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			h, err := pf.Screen.WaitForVisibleChangeContext(ctx, r, poll, vfStable)
+			initial, err := pf.Screen.GrabRegionHash(ctx, r)
 			if err != nil {
 				return err
+			}
+			h, err := pf.Screen.WaitForChange(ctx, r, initial, poll)
+			if err != nil {
+				return err
+			}
+			if vfStable > 1 {
+				h, err = find.WaitForNoChange(ctx, pf.Screen.Screenshotter, r, vfStable, poll, nil)
+				if err != nil {
+					return err
+				}
 			}
 			fmt.Printf("%08x\n", h)
 			return nil
@@ -1346,7 +1347,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			if err != nil {
 				return err
 			}
-			pt, err := pf.Screen.FindColorContext(context.Background(), r, c, colorTolerance)
+			pt, err := pf.Screen.FindColor(r, c, colorTolerance)
 			if err != nil {
 				return err
 			}

--- a/docs-cli/pf_screen.md
+++ b/docs-cli/pf_screen.md
@@ -21,6 +21,7 @@ Screen capture operations
 ### SEE ALSO
 
 * [pf](pf.md)	 - perfuncted — screen automation CLI
+* [pf screen capture-region](pf_screen_capture-region.md)	 - Auto-generated wrapper for perfuncted.CaptureRegion
 * [pf screen grab](pf_screen_grab.md)	 - Capture a screen region and save as PNG
 * [pf screen hash](pf_screen_hash.md)	 - Print the CRC32 pixel hash of a screen region
 * [pf screen pixel](pf_screen_pixel.md)	 - Print the RGB colour of a single pixel

--- a/docs-cli/pf_screen_capture-region.md
+++ b/docs-cli/pf_screen_capture-region.md
@@ -1,0 +1,30 @@
+## pf screen capture-region
+
+Auto-generated wrapper for perfuncted.CaptureRegion
+
+```
+pf screen capture-region [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for capture-region
+      --path string   path
+      --rect string   x0,y0,x1,y1 (default "0,0,1920,1080")
+```
+
+### Options inherited from parent commands
+
+```
+      --max-x int32            input coordinate space width (default 1920)
+      --max-y int32            input coordinate space height (default 1080)
+      --nested                 auto-detect and connect to a nested Wayland session in /tmp
+      --trace-actions          print each API action to stderr as it runs
+      --trace-delay duration   sleep after each traced action
+```
+
+### SEE ALSO
+
+* [pf screen](pf_screen.md)	 - Screen capture operations
+

--- a/docs-cli/pf_window.md
+++ b/docs-cli/pf_window.md
@@ -32,4 +32,5 @@ Window management
 * [pf window minimize](pf_window_minimize.md)	 - Minimize a window by title
 * [pf window move](pf_window_move.md)	 - Move a window to absolute screen coordinates
 * [pf window resize](pf_window_resize.md)	 - Resize a window
+* [pf window restore](pf_window_restore.md)	 - Auto-generated wrapper for perfuncted.Restore
 

--- a/docs-cli/pf_window_get-geometry.md
+++ b/docs-cli/pf_window_get-geometry.md
@@ -1,0 +1,28 @@
+## pf window get-geometry
+
+Print geometry for a window
+
+```
+pf window get-geometry <title> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get-geometry
+```
+
+### Options inherited from parent commands
+
+```
+      --max-x int32            input coordinate space width (default 1920)
+      --max-y int32            input coordinate space height (default 1080)
+      --nested                 auto-detect and connect to a nested Wayland session in /tmp
+      --trace-actions          print each API action to stderr as it runs
+      --trace-delay duration   sleep after each traced action
+```
+
+### SEE ALSO
+
+* [pf window](pf_window.md)	 - Window management
+

--- a/docs-cli/pf_window_is-visible.md
+++ b/docs-cli/pf_window_is-visible.md
@@ -1,0 +1,28 @@
+## pf window is-visible
+
+Return whether a window is visible
+
+```
+pf window is-visible <title> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for is-visible
+```
+
+### Options inherited from parent commands
+
+```
+      --max-x int32            input coordinate space width (default 1920)
+      --max-y int32            input coordinate space height (default 1080)
+      --nested                 auto-detect and connect to a nested Wayland session in /tmp
+      --trace-actions          print each API action to stderr as it runs
+      --trace-delay duration   sleep after each traced action
+```
+
+### SEE ALSO
+
+* [pf window](pf_window.md)	 - Window management
+

--- a/docs-cli/pf_window_restore.md
+++ b/docs-cli/pf_window_restore.md
@@ -1,0 +1,29 @@
+## pf window restore
+
+Auto-generated wrapper for perfuncted.Restore
+
+```
+pf window restore [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for restore
+      --pattern string   pattern
+```
+
+### Options inherited from parent commands
+
+```
+      --max-x int32            input coordinate space width (default 1920)
+      --max-y int32            input coordinate space height (default 1080)
+      --nested                 auto-detect and connect to a nested Wayland session in /tmp
+      --trace-actions          print each API action to stderr as it runs
+      --trace-delay duration   sleep after each traced action
+```
+
+### SEE ALSO
+
+* [pf window](pf_window.md)	 - Window management
+

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -403,7 +403,7 @@ func TestSessionLifecycle(t *testing.T) {
 	if _, err := waitForWindow(pf, app.winMatch, 30*time.Second); err != nil {
 		t.Fatalf("wait for %s window: %v", app.name, err)
 	}
-	if err := pf.Window.ActivateContext(context.Background(), app.winMatch); err != nil {
+	if err := pf.Window.Activate(app.winMatch); err != nil {
 		t.Fatalf("activate %s: %v", app.name, err)
 	}
 	// Give the editor a moment to fully focus before typing.
@@ -418,7 +418,7 @@ func TestSessionLifecycle(t *testing.T) {
 	}
 	// Wait for the save to complete before closing.
 	time.Sleep(1 * time.Second)
-	if err := pf.Window.CloseWindowContext(context.Background(), app.winMatch); err != nil {
+	if err := pf.Window.CloseWindow(app.winMatch); err != nil {
 		t.Fatalf("close window: %v", err)
 	}
 	// Give the close dialog a moment to appear and process.
@@ -467,7 +467,7 @@ func compositorKind(rt env.Runtime) string {
 
 func runScreenSmoke(t *testing.T, s *suite) {
 	t.Helper()
-	w, h, err := s.pf.Screen.ResolutionContext(context.Background())
+	w, h, err := s.pf.Screen.Resolution()
 	if err != nil {
 		t.Fatalf("resolution: %v", err)
 	}
@@ -476,40 +476,40 @@ func runScreenSmoke(t *testing.T, s *suite) {
 	}
 
 	rect := image.Rect(0, 0, min(w, 200), min(h, 200))
-	img, err := s.pf.Screen.GrabContext(context.Background(), rect)
+	img, err := s.pf.Screen.Grab(context.Background(), rect)
 	if err != nil {
 		t.Fatalf("grab: %v", err)
 	}
-	if _, err := s.pf.Screen.GrabHashContext(context.Background(), rect); err != nil {
+	if _, err := s.pf.Screen.GrabRegionHash(context.Background(), rect); err != nil {
 		t.Fatalf("grab hash: %v", err)
 	}
 	// Grab hash of full screen
 	fullScreenRect := image.Rect(0, 0, w, h)
-	if _, err := s.pf.Screen.GrabHashContext(context.Background(), fullScreenRect); err != nil {
+	if _, err := s.pf.Screen.GrabRegionHash(context.Background(), fullScreenRect); err != nil {
 		t.Fatalf("grab full hash: %v", err)
 	}
 
 	tmp := filepath.Join(t.TempDir(), "capture.png")
-	if err := s.pf.Screen.CaptureRegionContext(context.Background(), rect, tmp); err != nil {
+	if err := s.pf.Screen.CaptureRegion(rect, tmp); err != nil {
 		t.Fatalf("capture region: %v", err)
 	}
 	if _, err := os.Stat(tmp); err != nil {
 		t.Fatalf("capture region output missing: %v", err)
 	}
-	if _, err := s.pf.Screen.GetPixelContext(context.Background(), rect.Min.X, rect.Min.Y); err != nil {
+	if _, err := s.pf.Screen.GetPixel(rect.Min.X, rect.Min.Y); err != nil {
 		t.Fatalf("get pixel: %v", err)
 	}
-	if _, err := s.pf.Screen.GetMultiplePixelsContext(context.Background(), []image.Point{{rect.Min.X, rect.Min.Y}}); err != nil {
+	if _, err := s.pf.Screen.GetMultiplePixels([]image.Point{{rect.Min.X, rect.Min.Y}}); err != nil {
 		t.Fatalf("get multiple pixels: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	if _, err := s.pf.Screen.WaitForFnContext(ctx, rect, func(i image.Image) bool { return i != nil }, 100*time.Millisecond); err != nil {
+	if _, err := s.pf.Screen.WaitForFn(ctx, rect, func(i image.Image) bool { return i != nil }, 100*time.Millisecond); err != nil {
 		t.Fatalf("wait for fn: %v", err)
 	}
 
-	pt, err := s.pf.Screen.FindColorContext(context.Background(), rect, colorAt(img, rect.Min.X, rect.Min.Y), 0)
+	pt, err := s.pf.Screen.FindColor(rect, colorAt(img, rect.Min.X, rect.Min.Y), 0)
 	if err != nil {
 		t.Fatalf("find color: %v", err)
 	}
@@ -518,7 +518,7 @@ func runScreenSmoke(t *testing.T, s *suite) {
 	}
 
 	refRect := image.Rect(rect.Min.X, rect.Min.Y, min(rect.Min.X+20, rect.Max.X), min(rect.Min.Y+20, rect.Max.Y))
-	ref, err := s.pf.Screen.GrabContext(context.Background(), refRect)
+	ref, err := s.pf.Screen.Grab(context.Background(), refRect)
 	if err == nil {
 		// WaitWithTolerance is not exposed; skip advanced tolerance testing
 		_ = ref
@@ -548,11 +548,11 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 		t.Fatalf("wait for %s window: %v", app.name, err)
 	}
 
-	if err := s.pf.Window.ActivateContext(context.Background(), app.winMatch); err != nil {
+	if err := s.pf.Window.Activate(app.winMatch); err != nil {
 		t.Fatalf("activate %s: %v", app.name, err)
 	}
 
-	if err := s.pf.Window.MaximizeContext(context.Background(), app.winMatch); err != nil {
+	if err := s.pf.Window.Maximize(app.winMatch); err != nil {
 		t.Fatalf("maximize window %v", err)
 	}
 
@@ -560,7 +560,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 	if _, err := waitForWindow(s.pf, docName, 20*time.Second); err != nil {
 		t.Fatalf("wait for %s document title %q: %v", app.name, docName, err)
 	}
-	active, err := s.pf.Window.ActiveTitleContext(context.Background())
+	active, err := s.pf.Window.ActiveTitle()
 	if err != nil {
 		t.Fatalf("active title: %v", err)
 	}
@@ -568,7 +568,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 		t.Fatalf("active title %q does not match %q", active, app.winMatch)
 	}
 
-	info, err := s.pf.Window.FindByTitleContext(context.Background(), app.winMatch)
+	info, err := s.pf.Window.FindByTitle(app.winMatch)
 	if err != nil {
 		t.Fatalf("find window: %v", err)
 	}
@@ -576,7 +576,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 	if rect.Empty() {
 		t.Fatal("geometry returned empty rect")
 	}
-	screenW, screenH, err := s.pf.Screen.ResolutionContext(context.Background())
+	screenW, screenH, err := s.pf.Screen.Resolution()
 	if err != nil {
 		t.Fatalf("resolution: %v", err)
 	}
@@ -600,7 +600,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 	}
 	ctxFocus, cancelFocus := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFocus()
-	if _, err := s.pf.Screen.WaitForStableContext(ctxFocus, typingRect, 3, 100*time.Millisecond); err != nil {
+	if _, err := find.WaitForNoChange(ctxFocus, s.pf.Screen.Screenshotter, typingRect, 3, 100*time.Millisecond, nil); err != nil {
 		t.Fatalf("wait for editor focus to settle: %v", err)
 	}
 	if err := s.pf.Input.Type("Integration"); err != nil {
@@ -608,17 +608,17 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 	}
 	ctxType, cancelType := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelType()
-	if _, err := s.pf.Screen.WaitForNoChangeContext(ctxType, typingRect, 3, 100*time.Millisecond); err != nil {
+	if _, err := find.WaitForNoChange(ctxType, s.pf.Screen.Screenshotter, typingRect, 3, 100*time.Millisecond, nil); err != nil {
 		t.Fatalf("wait for typed text to settle: %v", err)
 	}
 
-	if _, err := s.pf.Screen.GrabHashContext(context.Background(), captureRect); err != nil {
+	if _, err := s.pf.Screen.GrabRegionHash(context.Background(), captureRect); err != nil {
 		t.Fatalf("grab hash: %v", err)
 	}
-	if _, err := s.pf.Screen.GetMultiplePixelsContext(context.Background(), []image.Point{{captureRect.Min.X, captureRect.Min.Y}, {captureRect.Min.X + 1, captureRect.Min.Y + 1}}); err != nil {
+	if _, err := s.pf.Screen.GetMultiplePixels([]image.Point{{captureRect.Min.X, captureRect.Min.Y}, {captureRect.Min.X + 1, captureRect.Min.Y + 1}}); err != nil {
 		t.Fatalf("get multiple pixels: %v", err)
 	}
-	if _, err := s.pf.Screen.GetPixelContext(context.Background(), captureRect.Min.X, captureRect.Min.Y); err != nil {
+	if _, err := s.pf.Screen.GetPixel(captureRect.Min.X, captureRect.Min.Y); err != nil {
 		t.Fatalf("get pixel: %v", err)
 	}
 	// Use a tiny 10x10 region at the center of the window for pixel
@@ -627,13 +627,13 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 	cx := rect.Min.X + rect.Dx()/2
 	cy := rect.Min.Y + rect.Dy()/2
 	tinyRect := image.Rect(cx-5, cy-5, cx+5, cy+5)
-	tinyImg, err := s.pf.Screen.GrabContext(context.Background(), tinyRect)
+	tinyImg, err := s.pf.Screen.Grab(context.Background(), tinyRect)
 	if err != nil {
 		t.Fatalf("grab tiny rect: %v", err)
 	}
 	scanCtx, scanCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer scanCancel()
-	if _, err := s.pf.Screen.ScanForContext(scanCtx, []image.Rectangle{tinyRect}, []uint32{find.PixelHash(tinyImg, nil)}, 100*time.Millisecond); err != nil {
+	if _, err := s.pf.Screen.ScanFor(scanCtx, []image.Rectangle{tinyRect}, []uint32{find.PixelHash(tinyImg, nil)}, 100*time.Millisecond); err != nil {
 		t.Fatalf("scan for: %v", err)
 	}
 
@@ -662,10 +662,10 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 		t.Fatalf("saved file %q does not contain typed text", saveFile)
 	}
 
-	if err := s.pf.Window.ResizeContext(context.Background(), app.winMatch, 800, 600); err != nil {
+	if err := s.pf.Window.Resize(app.winMatch, 800, 600); err != nil {
 		t.Fatalf("resize: %v", err)
 	}
-	if err := s.pf.Window.CloseWindowContext(context.Background(), app.winMatch); err != nil {
+	if err := s.pf.Window.CloseWindow(app.winMatch); err != nil {
 		t.Fatalf("close window: %v", err)
 	}
 	ctxClose, cancelClose := context.WithTimeout(context.Background(), 30*time.Second)
@@ -689,14 +689,14 @@ func runBrowserScenario(t *testing.T, s *suite, app appSpec) {
 	if _, err := waitForWindow(s.pf, app.winMatch, 90*time.Second); err != nil {
 		t.Fatalf("wait for browser window: %v", err)
 	}
-	if err := s.pf.Window.ActivateContext(context.Background(), app.winMatch); err != nil {
+	if err := s.pf.Window.Activate(app.winMatch); err != nil {
 		t.Fatalf("activate browser: %v", err)
 	}
 
 	if err := s.pf.Input.Type("{ctrl+l}"); err != nil {
 		t.Fatalf("ctrl+l: %v", err)
 	}
-	if err := s.pf.TypeFast("about:support"); err != nil {
+	if err := s.pf.Paste("about:support"); err != nil {
 		t.Fatalf("type address: %v", err)
 	}
 	if err := s.pf.Input.Type("{enter}"); err != nil {
@@ -706,7 +706,7 @@ func runBrowserScenario(t *testing.T, s *suite, app appSpec) {
 	rect := image.Rect(0, 0, 100, 100)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if _, err := s.pf.Screen.WaitForStableContext(ctx, rect, 3, 500*time.Millisecond); err != nil {
+	if _, err := find.WaitForNoChange(ctx, s.pf.Screen.Screenshotter, rect, 3, 500*time.Millisecond, nil); err != nil {
 		t.Fatalf("wait for stable: %v", err)
 	}
 }
@@ -753,7 +753,7 @@ func waitForWindow(pf *perfuncted.Perfuncted, pattern string, timeout time.Durat
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		info, err := pf.Window.FindByTitleContext(ctx, pattern)
+		info, err := pf.Window.FindByTitle(pattern)
 		if err == nil {
 			return info, nil
 		}
@@ -771,7 +771,7 @@ func waitForWindowClose(pf *perfuncted.Perfuncted, pattern string, timeout time.
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		_, err := pf.Window.FindByTitleContext(ctx, pattern)
+		_, err := pf.Window.FindByTitle(pattern)
 		if err != nil {
 			return nil
 		}

--- a/perfuncted.go
+++ b/perfuncted.go
@@ -151,37 +151,17 @@ type Perfuncted struct {
 	trace     *actionTracer
 }
 
+// Paste writes text to the clipboard and sends the paste key combo. If no
+// clipboard backend is available it falls back to per-character typing.
 func (p *Perfuncted) Paste(text string) error {
-	return p.PasteContext(context.Background(), text)
-}
-
-func (p *Perfuncted) PasteContext(ctx context.Context, text string) error {
 	if p == nil {
 		return fmt.Errorf("perfuncted: nil Perfuncted")
 	}
 	p.traceAction(fmt.Sprintf("paste text=%q", text))
-	return p.Clipboard.pasteWithInputContext(ctx, text, p.Input)
-}
-
-// TypeFast types text quickly by using the clipboard + PasteCombo when a
-// clipboard backend is available. It falls back to per-character typing via
-// the Inputter Type method when the clipboard is unavailable.
-func (p *Perfuncted) TypeFast(text string) error {
-	return p.TypeFastContext(context.Background(), text)
-}
-
-func (p *Perfuncted) TypeFastContext(ctx context.Context, text string) error {
-	if p == nil {
-		return fmt.Errorf("perfuncted: nil Perfuncted")
-	}
-	p.traceAction(fmt.Sprintf("type-fast text=%q", text))
-	// Prefer clipboard paste when available; this uses the session's clipboard
-	// backend (wl-copy/wl-paste) and sends the paste key combo via the input
-	// bundle. Falls back to Type which emits per-character key events.
 	if p.Clipboard.Clipboard != nil {
-		return p.Clipboard.pasteWithInputContext(ctx, text, p.Input)
+		return p.Clipboard.pasteWithInputContext(context.Background(), text, p.Input)
 	}
-	return p.Input.typeContext(ctx, text)
+	return p.Input.typeContext(context.Background(), text)
 }
 
 func New(opts Options) (*Perfuncted, error) {

--- a/perfuncted_test.go
+++ b/perfuncted_test.go
@@ -71,19 +71,19 @@ func TestBundleSmoke(t *testing.T) {
 	})
 
 	t.Run("Screen", func(t *testing.T) {
-		if _, err := pf.Screen.GetPixelContext(context.Background(), 5, 5); err != nil {
+		if _, err := pf.Screen.GetPixel(5, 5); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := pf.Screen.GetMultiplePixelsContext(context.Background(), []image.Point{{1, 1}}); err != nil {
+		if _, err := pf.Screen.GetMultiplePixels([]image.Point{{1, 1}}); err != nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("Window", func(t *testing.T) {
-		_ = pf.Window.ResizeContext(context.Background(), "Firefox", 800, 600)
-		_ = pf.Window.MinimizeContext(context.Background(), "Firefox")
-		_ = pf.Window.MaximizeContext(context.Background(), "Firefox")
-		_ = pf.Window.RestoreContext(context.Background(), "Firefox")
+		_ = pf.Window.Resize("Firefox", 800, 600)
+		_ = pf.Window.Minimize("Firefox")
+		_ = pf.Window.Maximize("Firefox")
+		_ = pf.Window.Restore("Firefox")
 	})
 }
 
@@ -177,7 +177,7 @@ func TestWindowBundle(t *testing.T) {
 		t.Errorf("unexpected list: %v", wins)
 	}
 
-	if err := pf.Window.ActivateContext(context.Background(), "Firefox"); err != nil {
+	if err := pf.Window.Activate("Firefox"); err != nil {
 		t.Fatal(err)
 	}
 	if len(mgr.Activated) != 1 || mgr.Activated[0] != "Firefox" {
@@ -190,7 +190,7 @@ func TestScreenBundleHashing(t *testing.T) {
 	sc := &pftest.Screenshotter{Frames: []image.Image{img}}
 	pf := pftest.New(sc, nil, nil, nil)
 
-	h1, err := pf.Screen.GrabHashContext(context.Background(), image.Rect(0, 0, 10, 10))
+	h1, err := pf.Screen.GrabRegionHash(context.Background(), image.Rect(0, 0, 10, 10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,8 +198,8 @@ func TestScreenBundleHashing(t *testing.T) {
 		t.Error("expected non-zero hash")
 	}
 
-	// GrabFullHash - equivalent to GrabHashContext with empty rect
-	h2, err := pf.Screen.GrabHashContext(context.Background(), image.Rectangle{})
+	// GrabFullHash - equivalent to GrabRegionHash with empty rect
+	h2, err := pf.Screen.GrabFullHash(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestWaitForVisibleChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	h, err := pf.Screen.WaitForVisibleChangeContext(ctx, image.Rect(0, 0, 10, 10), 10*time.Millisecond, 2)
+	h, err := pf.Screen.WaitForSettle(ctx, image.Rect(0, 0, 10, 10), func() {}, 2, 10*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestWaitForSettle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	h, err := pf.Screen.WaitForSettleContext(ctx, image.Rect(0, 0, 10, 10), func() {
+	h, err := pf.Screen.WaitForSettle(ctx, image.Rect(0, 0, 10, 10), func() {
 		// simulate action that causes change
 	}, 3, 10*time.Millisecond)
 

--- a/pftest/pftest_test.go
+++ b/pftest/pftest_test.go
@@ -1,7 +1,6 @@
 package pftest_test
 
 import (
-	"context"
 	"image"
 	"image/color"
 	"testing"
@@ -23,8 +22,8 @@ func TestNewAssemblesAllBackends(t *testing.T) {
 	}
 
 	// Exercise each bundle through the assembled Perfuncted.
-	if _, err := pf.Screen.GrabContext(context.Background(), image.Rectangle{}); err != nil {
-		t.Errorf("GrabContext: %v", err)
+	if _, _, err := pf.Screen.Resolution(); err != nil {
+		t.Errorf("Resolution: %v", err)
 	}
 	if err := pf.Input.Type("{enter}"); err != nil {
 		t.Errorf("Type: %v", err)
@@ -40,7 +39,7 @@ func TestNewNilBackends(t *testing.T) {
 		t.Fatal("New returned nil")
 	}
 	// All bundles are zero-valued; operations should return errors, not panic.
-	if _, err := pf.Screen.GrabContext(context.Background(), image.Rectangle{}); err == nil {
+	if _, _, err := pf.Screen.Resolution(); err == nil {
 		t.Error("expected error for nil screen")
 	}
 	if err := pf.Input.Type("{ctrl+s}"); err == nil {

--- a/scripts/verify_cli_api.go
+++ b/scripts/verify_cli_api.go
@@ -119,12 +119,10 @@ func skipMethodForCLISync(name string) bool {
 		return true
 	}
 	switch name {
-	case "CaptureRegion",
-		"FindColor",
+	case "FindColor",
 		"GetMultiplePixels",
 		"IterateWindows",
 		"LocateExact",
-		"Restore",
 		"ScanFor",
 		"WaitFor",
 		"WaitForChange",
@@ -223,7 +221,6 @@ func main() {
 			"get-geometry":  true,
 			"is-visible":    true,
 			"iterate":       true,
-			"restore":       true,
 		},
 		"screen": {
 			"pixel":      true,

--- a/scripts/verify_cli_api.go
+++ b/scripts/verify_cli_api.go
@@ -119,13 +119,19 @@ func skipMethodForCLISync(name string) bool {
 		return true
 	}
 	switch name {
-	case "FindColor",
+	case "CaptureRegion",
+		"FindColor",
 		"GetMultiplePixels",
+		"IterateWindows",
 		"LocateExact",
+		"Restore",
 		"ScanFor",
+		"WaitFor",
+		"WaitForChange",
+		"WaitForClose",
 		"WaitForFn",
-		"WaitForLocate",
-		"WaitForSettle":
+		"WaitForSettle",
+		"WaitForWindow":
 		return true
 	default:
 		return false
@@ -216,6 +222,8 @@ func main() {
 			"find-by-title": true,
 			"get-geometry":  true,
 			"is-visible":    true,
+			"iterate":       true,
+			"restore":       true,
 		},
 		"screen": {
 			"pixel":      true,


### PR DESCRIPTION
## Summary

This PR cleans up the public API surface of the `perfuncted` library by removing redundant and low-value exports.

### Changes

**ScreenBundle**
- All `*Context` methods removed; clean wrappers (no ctx) added for non-polling methods
- Polling methods (`WaitFor`, `WaitForChange`, `WaitForSettle`, `WaitForFn`, `ScanFor`) keep ctx param but drop `Context` suffix
- WaitFor family consolidated from 9 → 4: removed `WaitForAnyChange`, `WaitForStableOrTimeout`, `WaitForNoChange`, `WaitForStable`, `WaitForVisibleChange`
- `grab`/`grabHash` unexported (internal building blocks)

**WindowBundle**
- All `*Context` methods replaced with clean wrappers using `context.Background()` internally
- Added `WaitForWindow(ctx, pattern, poll)` and `WaitForClose(ctx, pattern, poll)`

**perfuncted.go**
- Removed `TypeFast`, `TypeFastContext`, `PasteContext`
- `Paste` now absorbs clipboard-with-fallback-to-Type behaviour

**Internal / CLI**
- `cmd/pf/root.go` updated to use new API throughout
- `scripts/verify_cli_api.go` skip-list updated for removed/new methods
- All test files updated

### Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all packages green)
- `gofmt -l .` ✅ (no changes needed)
- `go run ./scripts/verify_cli_api.go` ✅