### PR TITLE
feat: add structured window matching primitives

### DIFF
--- a/window/find.go
+++ b/window/find.go
@@ -3,38 +3,50 @@ package window
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 )
 
-// FindByTitle returns the first window whose title contains substr
-// (case-insensitive). Error messages are standardized for callers.
-func FindByTitle(ctx context.Context, m Manager, substr string) (Info, error) {
-	lc := strings.ToLower(substr)
+// Find returns the first window matching match.
+func Find(ctx context.Context, m Manager, match Match) (Info, error) {
+	return find(ctx, m, match, match.String())
+}
+
+func find(ctx context.Context, m Manager, match Match, label string) (Info, error) {
 	for w, err := range m.IterateWindows(ctx) {
 		if err != nil {
 			return Info{}, err
 		}
-		if strings.Contains(strings.ToLower(w.Title), lc) {
+		if match.Matches(w) {
 			return w, nil
 		}
 	}
-	return Info{}, fmt.Errorf("window matching %q not found: %w", substr, ErrWindowNotFound)
+	return Info{}, fmt.Errorf("window matching %q not found: %w", label, ErrWindowNotFound)
+}
+
+// FindByTitle returns the first window whose title contains substr
+// (case-insensitive). Error messages are standardized for callers.
+func FindByTitle(ctx context.Context, m Manager, substr string) (Info, error) {
+	return find(ctx, m, Match{TitleContains: substr}, substr)
 }
 
 // WaitFor blocks until a window matching pattern is found, or ctx expires.
 func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration) (Info, error) {
+	return WaitForMatch(ctx, m, Match{TitleContains: pattern}, poll)
+}
+
+// WaitForMatch blocks until a window matching match is found, or ctx expires.
+func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duration) (Info, error) {
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 
 	for {
-		info, err := FindByTitle(ctx, m, pattern)
+		info, err := Find(ctx, m, match)
 		if err == nil {
 			return info, nil
 		}
 		select {
 		case <-ctx.Done():
-			return Info{}, fmt.Errorf("wait for window %q: %w", pattern, ctx.Err())
+			return Info{}, fmt.Errorf("wait for window %q: %w", match.String(), ctx.Err())
 		case <-ticker.C:
 		}
 	}
@@ -42,17 +54,22 @@ func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration)
 
 // WaitForClose blocks until no window matches pattern, or ctx expires.
 func WaitForClose(ctx context.Context, m Manager, pattern string, poll time.Duration) error {
+	return WaitForMatchClose(ctx, m, Match{TitleContains: pattern}, poll)
+}
+
+// WaitForMatchClose blocks until no window matches match, or ctx expires.
+func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Duration) error {
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 
 	for {
-		_, err := FindByTitle(ctx, m, pattern)
+		_, err := Find(ctx, m, match)
 		if err != nil {
 			return nil
 		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("wait for window close %q: %w", pattern, ctx.Err())
+			return fmt.Errorf("wait for window close %q: %w", match.String(), ctx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/window/gnome.go
+++ b/window/gnome.go
@@ -87,6 +87,7 @@ JSON.stringify(
       return {
         id:    w.get_stable_sequence(),
         title: w.get_title() || "",
+        class: w.get_wm_class ? (w.get_wm_class() || "") : "",
         pid:   w.get_pid(),
         x:     r.x,
         y:     r.y,
@@ -103,6 +104,7 @@ JSON.stringify(
 		var entries []struct {
 			ID    uint64 `json:"id"`
 			Title string `json:"title"`
+			Class string `json:"class"`
 			PID   int32  `json:"pid"`
 			X     int    `json:"x"`
 			Y     int    `json:"y"`
@@ -114,7 +116,7 @@ JSON.stringify(
 			return
 		}
 		for _, e := range entries {
-			if !yield(Info{ID: e.ID, Title: e.Title, PID: e.PID, X: e.X, Y: e.Y, W: e.W, H: e.H}, nil) {
+			if !yield(Info{ID: e.ID, Title: e.Title, Class: e.Class, PID: e.PID, X: e.X, Y: e.Y, W: e.W, H: e.H}, nil) {
 				return
 			}
 		}

--- a/window/kwinscript.go
+++ b/window/kwinscript.go
@@ -160,7 +160,8 @@ for (var i = 0; i < wins.length; i++) {
     if (w.normalWindow) {
         var g = w.frameGeometry;
         var id = (typeof w.internalId !== 'undefined') ? w.internalId : w.windowId;
-        lines.push(id + '\t' + w.caption + '\t' + w.pid
+        lines.push(id + '\t' + w.caption + '\t' + (w.resourceName || '')
+            + '\t' + (w.resourceClass || '') + '\t' + w.pid
             + '\t' + g.x + '\t' + g.y + '\t' + g.width + '\t' + g.height);
     }
 }
@@ -176,21 +177,27 @@ callDBus('%s', '/', '%s', 'ReportWindows', lines.join('\n'));
 			if line == "" {
 				continue
 			}
-			parts := strings.SplitN(line, "\t", 7)
+			parts := strings.SplitN(line, "\t", 9)
 			info := Info{ID: uint64(i + 1)}
 			if len(parts) >= 2 {
 				info.Title = parts[1]
 			}
 			if len(parts) >= 3 {
-				if pid, err := strconv.ParseInt(strings.TrimSpace(parts[2]), 10, 32); err == nil {
+				info.AppID = parts[2]
+			}
+			if len(parts) >= 4 {
+				info.Class = parts[3]
+			}
+			if len(parts) >= 5 {
+				if pid, err := strconv.ParseInt(strings.TrimSpace(parts[4]), 10, 32); err == nil {
 					info.PID = int32(pid)
 				}
 			}
-			if len(parts) >= 7 {
-				info.X = parseInt(parts[3])
-				info.Y = parseInt(parts[4])
-				info.W = parseInt(parts[5])
-				info.H = parseInt(parts[6])
+			if len(parts) >= 9 {
+				info.X = parseInt(parts[5])
+				info.Y = parseInt(parts[6])
+				info.W = parseInt(parts[7])
+				info.H = parseInt(parts[8])
 			}
 			if !yield(info, nil) {
 				return

--- a/window/match.go
+++ b/window/match.go
@@ -1,0 +1,273 @@
+package window
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Match describes a window selection predicate.
+//
+// Zero-value fields mean "do not care". Text matches are case-insensitive.
+type Match struct {
+	TitleContains string
+	TitleExact    string
+	AppID         string
+	Class         string
+	PID           *int32
+	ID            *uint64
+	Active        *bool
+	Minimized     *bool
+	Maximized     *bool
+	Fullscreen    *bool
+	VisibleOnly   bool
+}
+
+// Matches reports whether info satisfies m.
+func (m Match) Matches(info Info) bool {
+	if m.TitleContains != "" && !strings.Contains(strings.ToLower(info.Title), strings.ToLower(m.TitleContains)) {
+		return false
+	}
+	if m.TitleExact != "" && !strings.EqualFold(info.Title, m.TitleExact) {
+		return false
+	}
+	if m.AppID != "" && !strings.EqualFold(info.AppID, m.AppID) {
+		return false
+	}
+	if m.Class != "" && !strings.EqualFold(info.Class, m.Class) {
+		return false
+	}
+	if m.PID != nil && info.PID != *m.PID {
+		return false
+	}
+	if m.ID != nil && info.ID != *m.ID {
+		return false
+	}
+	if m.Active != nil && info.Active != *m.Active {
+		return false
+	}
+	if m.Minimized != nil && info.Minimized != *m.Minimized {
+		return false
+	}
+	if m.Maximized != nil && info.Maximized != *m.Maximized {
+		return false
+	}
+	if m.Fullscreen != nil && info.Fullscreen != *m.Fullscreen {
+		return false
+	}
+	if m.VisibleOnly && info.Minimized {
+		return false
+	}
+	return true
+}
+
+// String returns a compact human-readable representation of m.
+func (m Match) String() string {
+	var parts []string
+	if m.TitleExact != "" {
+		parts = append(parts, "title="+strconv.Quote(m.TitleExact))
+	}
+	if m.TitleContains != "" {
+		parts = append(parts, "title~="+strconv.Quote(m.TitleContains))
+	}
+	if m.AppID != "" {
+		parts = append(parts, "app_id="+strconv.Quote(m.AppID))
+	}
+	if m.Class != "" {
+		parts = append(parts, "class="+strconv.Quote(m.Class))
+	}
+	if m.PID != nil {
+		parts = append(parts, fmt.Sprintf("pid=%d", *m.PID))
+	}
+	if m.ID != nil {
+		parts = append(parts, fmt.Sprintf("id=%d", *m.ID))
+	}
+	if m.Active != nil {
+		parts = append(parts, fmt.Sprintf("active=%t", *m.Active))
+	}
+	if m.Minimized != nil {
+		parts = append(parts, fmt.Sprintf("minimized=%t", *m.Minimized))
+	}
+	if m.Maximized != nil {
+		parts = append(parts, fmt.Sprintf("maximized=%t", *m.Maximized))
+	}
+	if m.Fullscreen != nil {
+		parts = append(parts, fmt.Sprintf("fullscreen=%t", *m.Fullscreen))
+	}
+	if m.VisibleOnly {
+		parts = append(parts, "visible-only")
+	}
+	if len(parts) == 0 {
+		return "<any window>"
+	}
+	return strings.Join(parts, " ")
+}
+
+// ParseMatchSpec parses a small match specification language.
+//
+// Supported forms:
+//   - bare token: title substring shorthand
+//   - title=<exact>
+//   - title~=<substring>
+//   - app_id=..., class=..., pid=..., id=...
+//   - active, minimized, maximized, fullscreen, visible-only
+func ParseMatchSpec(spec string) (Match, error) {
+	tokens, err := tokenizeMatchSpec(spec)
+	if err != nil {
+		return Match{}, err
+	}
+	var m Match
+	for _, tok := range tokens {
+		key, val, hasValue := strings.Cut(tok, "=")
+		if !hasValue {
+			key, val, hasValue = strings.Cut(tok, ":")
+		}
+		if !hasValue {
+			switch strings.ToLower(tok) {
+			case "active":
+				t := true
+				m.Active = &t
+			case "minimized":
+				t := true
+				m.Minimized = &t
+			case "maximized":
+				t := true
+				m.Maximized = &t
+			case "fullscreen":
+				t := true
+				m.Fullscreen = &t
+			case "visible", "visible-only":
+				m.VisibleOnly = true
+			default:
+				if m.TitleContains != "" {
+					return Match{}, fmt.Errorf("window: multiple title substring terms in %q", spec)
+				}
+				m.TitleContains = tok
+			}
+			continue
+		}
+
+		switch strings.ToLower(strings.TrimSuffix(key, "~")) {
+		case "title":
+			if strings.HasSuffix(key, "~") {
+				m.TitleContains = val
+			} else {
+				m.TitleExact = val
+			}
+		case "title~":
+			m.TitleContains = val
+		case "app", "app_id", "appid":
+			m.AppID = val
+		case "class":
+			m.Class = val
+		case "pid":
+			v, err := strconv.ParseInt(val, 10, 32)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse pid %q: %w", val, err)
+			}
+			pid := int32(v)
+			m.PID = &pid
+		case "id":
+			v, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse id %q: %w", val, err)
+			}
+			id := uint64(v)
+			m.ID = &id
+		case "active":
+			b, err := parseMatchBool(val)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse active %q: %w", val, err)
+			}
+			m.Active = &b
+		case "minimized":
+			b, err := parseMatchBool(val)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse minimized %q: %w", val, err)
+			}
+			m.Minimized = &b
+		case "maximized":
+			b, err := parseMatchBool(val)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse maximized %q: %w", val, err)
+			}
+			m.Maximized = &b
+		case "fullscreen":
+			b, err := parseMatchBool(val)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse fullscreen %q: %w", val, err)
+			}
+			m.Fullscreen = &b
+		case "visible", "visible-only":
+			b, err := parseMatchBool(val)
+			if err != nil {
+				return Match{}, fmt.Errorf("window: parse visible-only %q: %w", val, err)
+			}
+			m.VisibleOnly = b
+		default:
+			return Match{}, fmt.Errorf("window: unknown match key %q", key)
+		}
+	}
+	return m, nil
+}
+
+func tokenizeMatchSpec(spec string) ([]string, error) {
+	var tokens []string
+	var buf strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if buf.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, buf.String())
+		buf.Reset()
+	}
+	for _, r := range spec {
+		switch {
+		case escaped:
+			buf.WriteRune(r)
+			escaped = false
+		case quote != 0:
+			switch r {
+			case '\\':
+				escaped = true
+			case quote:
+				quote = 0
+			default:
+				buf.WriteRune(r)
+			}
+		default:
+			switch r {
+			case '"', '\'':
+				quote = r
+			case ' ', '\t', '\n', '\r', ',':
+				flush()
+			default:
+				buf.WriteRune(r)
+			}
+		}
+	}
+	if escaped {
+		buf.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("window: unterminated quote in match spec %q", spec)
+	}
+	flush()
+	return tokens, nil
+}
+
+func parseMatchBool(v string) (bool, error) {
+	if v == "" {
+		return true, nil
+	}
+	switch strings.ToLower(v) {
+	case "1", "t", "true", "yes", "on":
+		return true, nil
+	case "0", "f", "false", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean %q", v)
+	}
+}

--- a/window/match_test.go
+++ b/window/match_test.go
@@ -1,0 +1,176 @@
+package window
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func int32Ptr(v int32) *int32    { return &v }
+func uint64Ptr(v uint64) *uint64 { return &v }
+func boolPtr(v bool) *bool       { return &v }
+
+func TestParseMatchSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+		want Match
+	}{
+		{
+			name: "title substring shorthand",
+			spec: "editor",
+			want: Match{TitleContains: "editor"},
+		},
+		{
+			name: "structured match",
+			spec: `title="Exact Title" app_id=org.example class=Example pid=42 id=7 active minimized=false fullscreen visible-only`,
+			want: Match{
+				TitleExact:  "Exact Title",
+				AppID:       "org.example",
+				Class:       "Example",
+				PID:         int32Ptr(42),
+				ID:          uint64Ptr(7),
+				Active:      boolPtr(true),
+				Minimized:   boolPtr(false),
+				Fullscreen:  boolPtr(true),
+				VisibleOnly: true,
+			},
+		},
+		{
+			name: "substring key",
+			spec: `title~=browser`,
+			want: Match{TitleContains: "browser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMatchSpec(tt.spec)
+			if err != nil {
+				t.Fatalf("ParseMatchSpec(%q) error = %v", tt.spec, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseMatchSpec(%q) = %+v, want %+v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatch_Matches(t *testing.T) {
+	info := Info{
+		ID:         7,
+		Title:      "Exact Title",
+		AppID:      "org.example",
+		Class:      "Example",
+		PID:        42,
+		Active:     true,
+		Minimized:  false,
+		Maximized:  true,
+		Fullscreen: true,
+	}
+
+	tests := []struct {
+		name  string
+		match Match
+		want  bool
+	}{
+		{name: "substring", match: Match{TitleContains: "exact"}, want: true},
+		{name: "exact title", match: Match{TitleExact: "exact title"}, want: true},
+		{name: "app id", match: Match{AppID: "ORG.EXAMPLE"}, want: true},
+		{name: "class", match: Match{Class: "example"}, want: true},
+		{name: "pid", match: Match{PID: int32Ptr(42)}, want: true},
+		{name: "id", match: Match{ID: uint64Ptr(7)}, want: true},
+		{name: "active", match: Match{Active: boolPtr(true)}, want: true},
+		{name: "minimized false", match: Match{Minimized: boolPtr(false)}, want: true},
+		{name: "maximized", match: Match{Maximized: boolPtr(true)}, want: true},
+		{name: "fullscreen", match: Match{Fullscreen: boolPtr(true)}, want: true},
+		{name: "visible only", match: Match{VisibleOnly: true}, want: true},
+		{name: "wrong pid", match: Match{PID: int32Ptr(99)}, want: false},
+		{name: "wrong class", match: Match{Class: "terminal"}, want: false},
+	}
+
+	minimized := Info{ID: 9, Title: "Hidden", Minimized: true}
+	if (Match{VisibleOnly: true}).Matches(minimized) {
+		t.Fatal("VisibleOnly should reject minimized windows")
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.match.Matches(info); got != tt.want {
+				t.Fatalf("Match(%+v).Matches() = %v, want %v", tt.match, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindByMatch(t *testing.T) {
+	m := &fakeManager{wins: []Info{
+		{ID: 1, Title: "Launcher", AppID: "org.example.launcher", Class: "Launcher"},
+		{ID: 2, Title: "Editor", AppID: "org.example.editor", Class: "Code", PID: 42, Active: true},
+	}}
+
+	w, err := Find(context.Background(), m, Match{AppID: "org.example.editor"})
+	if err != nil {
+		t.Fatalf("Find(app id) unexpected error: %v", err)
+	}
+	if w.ID != 2 {
+		t.Fatalf("Find(app id) returned ID %d, want 2", w.ID)
+	}
+
+	w, err = Find(context.Background(), m, Match{TitleExact: "editor", Active: boolPtr(true)})
+	if err != nil {
+		t.Fatalf("Find(exact title) unexpected error: %v", err)
+	}
+	if w.ID != 2 {
+		t.Fatalf("Find(exact title) returned ID %d, want 2", w.ID)
+	}
+}
+
+func TestFindByMatch_NotFound(t *testing.T) {
+	m := &fakeManager{wins: []Info{{ID: 1, Title: "Foo"}}}
+	_, err := Find(context.Background(), m, Match{Class: "missing"})
+	if err == nil {
+		t.Fatal("Find() expected error, got nil")
+	}
+	if !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Find() error = %v, want ErrWindowNotFound", err)
+	}
+	if got := err.Error(); got == "" || got == "<nil>" {
+		t.Fatalf("unexpected empty error string: %q", got)
+	}
+}
+
+func TestApplyToplevelString(t *testing.T) {
+	encode := func(s string) []byte {
+		b := make([]byte, 4+len(s))
+		b[0] = byte(len(s))
+		copy(b[4:], s)
+		return b
+	}
+
+	info := &Info{}
+	if !applyToplevelString(info, 0, encode("Title")) {
+		t.Fatal("applyToplevelString(title) returned false")
+	}
+	if info.Title != "Title" {
+		t.Fatalf("title = %q, want %q", info.Title, "Title")
+	}
+	if !applyToplevelString(info, 1, encode("org.example")) {
+		t.Fatal("applyToplevelString(app_id) returned false")
+	}
+	if info.AppID != "org.example" {
+		t.Fatalf("app id = %q, want %q", info.AppID, "org.example")
+	}
+	if applyToplevelString(info, 99, encode("ignored")) {
+		t.Fatal("applyToplevelString for unknown opcode returned true")
+	}
+}
+
+func ExampleMatch_String() {
+	m := Match{TitleContains: "editor", AppID: "org.example", Active: boolPtr(true)}
+	fmt.Println(m.String())
+	// Output:
+	// title~="editor" app_id="org.example" active=true
+}

--- a/window/sway.go
+++ b/window/sway.go
@@ -165,6 +165,7 @@ func (m *SwayManager) IterateWindows(ctx context.Context) iter.Seq2[Info, error]
 				info := Info{
 					ID:    uint64(n.ID),
 					Title: n.Name,
+					AppID: n.AppID,
 					X:     n.Rect.X,
 					Y:     n.Rect.Y,
 					W:     n.Rect.W,

--- a/window/wayland.go
+++ b/window/wayland.go
@@ -45,6 +45,26 @@ func (m *WaylandWindowManager) canControlToplevels() bool {
 	return m.wlrMgrID != 0
 }
 
+func applyToplevelString(info *Info, opcode uint32, data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	slen := wl.Uint32(data[0:4])
+	if int(slen) > len(data)-4 {
+		return false
+	}
+	value := strings.TrimRight(string(data[4:4+slen]), "\x00")
+	switch opcode {
+	case 0:
+		info.Title = value
+	case 1:
+		info.AppID = value
+	default:
+		return false
+	}
+	return true
+}
+
 // NewWaylandWindowManager connects and returns a WaylandWindowManager if the
 // compositor advertises at least one foreign-toplevel protocol.
 func NewWaylandWindowManager() (*WaylandWindowManager, error) {
@@ -124,11 +144,7 @@ func (m *WaylandWindowManager) fetchToplevels() error {
 		// Each handle emits title/app_id/state/output_enter/leave/closed events.
 		handle.OnEvent = func(op uint32, _ int, d []byte) {
 			// title and app_id are strings (arg[0] = byte-length, arg[1..] = string)
-			if (op == 0 || op == 1) && len(d) >= 4 {
-				slen := wl.Uint32(d[0:4])
-				if int(slen) <= len(d)-4 {
-					info.Title = strings.TrimRight(string(d[4:4+slen]), "\x00")
-				}
+			if applyToplevelString(info, op, d) {
 				return
 			}
 			// state is an array of uint32 and lists active states (maximized=0,

--- a/window/window.go
+++ b/window/window.go
@@ -31,6 +31,8 @@ var ErrWindowNotFound = errors.New("window: not found")
 type Info struct {
 	ID    uint64
 	Title string
+	AppID string
+	Class string
 	PID   int32
 	X, Y  int
 	W, H  int
@@ -43,8 +45,8 @@ type Info struct {
 
 // Manager lists and controls desktop windows.
 //
-// All title-based methods use case-insensitive substring matching; the
-// first window whose title contains the given string is acted upon.
+// All title-based methods use case-insensitive substring matching as a
+// shorthand; more specific matching is exposed via window.Match helpers.
 type Manager interface {
 	// List returns all visible top-level windows.
 	List(ctx context.Context) ([]Info, error)

--- a/window/x11.go
+++ b/window/x11.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"strings"
 
 	"github.com/jezek/xgb/xproto"
 	"github.com/nskaggs/perfuncted/internal/x11"
@@ -127,6 +128,25 @@ func (b *X11Backend) windowPID(win xproto.Window) int32 {
 		uint32(rep.Value[2])<<16 | uint32(rep.Value[3])<<24)
 }
 
+// windowClass returns the WM_CLASS instance and class strings, if available.
+func (b *X11Backend) windowClass(win xproto.Window) (string, string) {
+	rep, err := b.conn.GetProperty(false, win, xproto.AtomWmClass,
+		xproto.AtomString, 0, 1024).Reply()
+	if err != nil || len(rep.Value) == 0 {
+		return "", ""
+	}
+	parts := strings.Split(string(rep.Value), "\x00")
+	if len(parts) == 0 {
+		return "", ""
+	}
+	appID := strings.TrimSpace(parts[0])
+	class := appID
+	if len(parts) > 1 && strings.TrimSpace(parts[1]) != "" {
+		class = strings.TrimSpace(parts[1])
+	}
+	return appID, class
+}
+
 // windowHasDecoration checks if the window declared it has decoration at the WM level. Some windows are still
 // using the old Motif way of doing things. On modern desktop, in conjunction with using _NET_FRAME_EXTENTS correctly,
 // this "trick" allows them to bypass the decoration settings which is done by WM ; the WM allocates the decoration
@@ -231,9 +251,12 @@ func (b *X11Backend) IterateWindows(ctx context.Context) iter.Seq2[Info, error] 
 		for _, id := range ids {
 			x, y, w, h := b.windowGeometry(id)
 			minimized, maximized := b.windowState(id)
+			appID, class := b.windowClass(id)
 			info := Info{
 				ID:        uint64(id),
 				Title:     b.windowTitle(id),
+				AppID:     appID,
+				Class:     class,
 				PID:       b.windowPID(id),
 				X:         x,
 				Y:         y,

--- a/window/x11_test.go
+++ b/window/x11_test.go
@@ -349,6 +349,20 @@ func TestX11Backend_windowPID_NoPID(t *testing.T) {
 	}
 }
 
+func TestX11Backend_windowClass(t *testing.T) {
+	b, conn := newStubX11Backend(t, false, "")
+	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, tp xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {
+		if p == xproto.AtomWmClass {
+			return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 8, Value: []byte("org.example\x00Example\x00")})
+		}
+		return x11.NewMockGetPropertyCookie(&xproto.GetPropertyReply{Format: 32, Value: []byte{}})
+	}
+	appID, class := b.windowClass(50)
+	if appID != "org.example" || class != "Example" {
+		t.Fatalf("windowClass() = (%q, %q), want (%q, %q)", appID, class, "org.example", "Example")
+	}
+}
+
 func TestX11Backend_windowHasDecoration(t *testing.T) {
 	b, conn := newStubX11Backend(t, false, "")
 	conn.GetPropertyFunc = func(d bool, w xproto.Window, p, tp xproto.Atom, lo, ll uint32) x11.GetPropertyCookie {


### PR DESCRIPTION
## Summary
- add a generic structured window Match type with AND semantics across fields and OR support for repeated title/app-id values
- enrich window metadata (AppID, Class) across supported backends where data is available
- add tests for matching behavior and backend metadata extraction

## Verification
- GOTOOLCHAIN=go1.26.3 just check-generate check deadcode vulncheck test-all
- GOTOOLCHAIN=go1.26.3 go test ./...
