### PR TITLE
Add Flatpak bundle validation and artifact upload

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,40 @@
+name: Flatpak
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: Build and validate bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      options: --privileged
+    env:
+      CGO_ENABLED: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Flatpak integration tests
+        run: go test -tags=integration ./flatpaktest -count=1 -v -timeout=60m
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perfuncted-flatpak
+          path: dist/flatpak/perfuncted.flatpak
+          if-no-files-found: error

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -23,6 +23,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Ensure Flatpak session helper is available
+        run: |
+          if command -v flatpak-session-helper >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y flatpak
+            exit 0
+          fi
+
+          if command -v dnf >/dev/null 2>&1; then
+            dnf install -y flatpak
+            exit 0
+          fi
+
+          if command -v apk >/dev/null 2>&1; then
+            apk add flatpak
+            exit 0
+          fi
+
+          echo "flatpak-session-helper is missing and no supported package manager was found" >&2
+          exit 1
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -14,39 +14,16 @@ jobs:
     name: Build and validate bundle
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
-      options: --privileged
     env:
       CGO_ENABLED: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Ensure Flatpak session helper is available
+      - name: Install Flatpak tooling
         run: |
-          if command -v flatpak-session-helper >/dev/null 2>&1; then
-            exit 0
-          fi
-
-          if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y flatpak
-            exit 0
-          fi
-
-          if command -v dnf >/dev/null 2>&1; then
-            dnf install -y flatpak
-            exit 0
-          fi
-
-          if command -v apk >/dev/null 2>&1; then
-            apk add flatpak
-            exit 0
-          fi
-
-          echo "flatpak-session-helper is missing and no supported package manager was found" >&2
-          exit 1
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y flatpak
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Run `pf info` to see exactly which backends are active on your system.
 
 ## Install
 
+**Flatpak bundle (CI artifact):**
+
+The Flatpak workflow attaches `dist/flatpak/perfuncted.flatpak` as an artifact.
+
+```bash
+flatpak install --user -y ./dist/flatpak/perfuncted.flatpak
+flatpak run io.github.nskaggs.perfuncted --help
+```
+
 **CLI:**
 
 ```bash
@@ -105,6 +114,7 @@ just test-integration-headless-wayland
 just test-integration-nested-x11
 just test-integration-nested-wayland
 just test-integration   # CI headless matrix
+just test-flatpak      # build, install, and validate the Flatpak bundle
 ```
 
 Optional: install `wl-clipboard` for Wayland clipboard round-trip verification and `xclip` for X11 clipboard round-trip verification.

--- a/flatpak/io.github.nskaggs.perfuncted.metainfo.xml
+++ b/flatpak/io.github.nskaggs.perfuncted.metainfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.nskaggs.perfuncted</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <developer id="io.github.nskaggs">
+    <name>Nicholas Skaggs</name>
+  </developer>
+  <name>perfuncted</name>
+  <summary>Go CLI for automating Linux desktop sessions</summary>
+  <description>
+    <p>perfuncted is a Go library and command-line tool for automating Linux desktop applications.</p>
+    <p>It detects the active session at runtime and selects the best available backend for input, window management, screen capture, and clipboard access.</p>
+  </description>
+  <url type="homepage">https://github.com/nskaggs/perfuncted</url>
+  <url type="bugtracker">https://github.com/nskaggs/perfuncted/issues</url>
+  <icon type="stock">io.github.nskaggs.perfuncted</icon>
+  <provides>
+    <binary>pf</binary>
+  </provides>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <content_rating type="oars-1.1" />
+  <keywords>
+    <keyword>automation</keyword>
+    <keyword>desktop</keyword>
+    <keyword>input</keyword>
+    <keyword>wayland</keyword>
+    <keyword>x11</keyword>
+  </keywords>
+  <releases>
+    <release version="0.3.1" date="2026-05-08">
+      <description>
+        <p>Current upstream release.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/flatpak/io.github.nskaggs.perfuncted.svg
+++ b/flatpak/io.github.nskaggs.perfuncted.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">perfuncted</title>
+  <desc id="desc">A terminal-style icon with the letters pf.</desc>
+  <defs>
+    <linearGradient id="bg" x1="72" y1="64" x2="456" y2="448" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#16222e"/>
+      <stop offset="1" stop-color="#070b11"/>
+    </linearGradient>
+    <linearGradient id="screen" x1="112" y1="128" x2="400" y2="392" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f1721"/>
+      <stop offset="1" stop-color="#091018"/>
+    </linearGradient>
+  </defs>
+  <rect x="32" y="32" width="448" height="448" rx="96" fill="url(#bg)"/>
+  <rect x="88" y="104" width="336" height="304" rx="36" fill="url(#screen)" stroke="#2dd4bf" stroke-width="10"/>
+  <rect x="88" y="104" width="336" height="58" rx="36" fill="#132231"/>
+  <circle cx="128" cy="133" r="11" fill="#fb7185"/>
+  <circle cx="164" cy="133" r="11" fill="#f59e0b"/>
+  <circle cx="200" cy="133" r="11" fill="#34d399"/>
+  <path d="M142 200h78v28h-78z" fill="#2dd4bf"/>
+  <path d="M242 200h110v14H242zM242 224h156v14H242zM142 246h176v14H142z" fill="#84f4e4"/>
+  <path d="M142 296h44v74h-24v-25h-20zM186 296h78v21h-54v18h46v21h-46v34h-24z" fill="#f8fafc"/>
+</svg>

--- a/flatpak/modules.txt
+++ b/flatpak/modules.txt
@@ -1,0 +1,73 @@
+# github.com/bendahl/uinput v1.7.0
+## explicit; go 1.13
+github.com/bendahl/uinput
+# github.com/cpuguy83/go-md2man/v2 v2.0.6
+## explicit; go 1.12
+github.com/cpuguy83/go-md2man/v2/md2man
+# github.com/godbus/dbus/v5 v5.2.2
+## explicit; go 1.20
+github.com/godbus/dbus/v5
+# github.com/inconshreveable/mousetrap v1.1.0
+## explicit; go 1.18
+github.com/inconshreveable/mousetrap
+# github.com/jezek/xgb v1.3.0
+## explicit; go 1.11
+github.com/jezek/xgb
+github.com/jezek/xgb/composite
+github.com/jezek/xgb/render
+github.com/jezek/xgb/shape
+github.com/jezek/xgb/xfixes
+github.com/jezek/xgb/xproto
+github.com/jezek/xgb/xtest
+# github.com/kr/text v0.2.0
+## explicit
+# github.com/russross/blackfriday/v2 v2.1.0
+## explicit
+github.com/russross/blackfriday/v2
+# github.com/spf13/cobra v1.10.2
+## explicit; go 1.15
+github.com/spf13/cobra
+github.com/spf13/cobra/doc
+# github.com/spf13/pflag v1.0.9
+## explicit; go 1.12
+github.com/spf13/pflag
+# go.uber.org/goleak v1.3.0
+## explicit; go 1.20
+go.uber.org/goleak
+go.uber.org/goleak/internal/stack
+# go.yaml.in/yaml/v3 v3.0.4
+## explicit; go 1.16
+go.yaml.in/yaml/v3
+# golang.org/x/mod v0.35.0
+## explicit; go 1.25.0
+golang.org/x/mod/semver
+# golang.org/x/sync v0.20.0
+## explicit; go 1.25.0
+golang.org/x/sync/errgroup
+# golang.org/x/sys v0.43.0
+## explicit; go 1.25.0
+golang.org/x/sys/unix
+# golang.org/x/tools v0.44.0
+## explicit; go 1.25.0
+golang.org/x/tools/go/ast/edge
+golang.org/x/tools/go/ast/inspector
+golang.org/x/tools/go/gcexportdata
+golang.org/x/tools/go/packages
+golang.org/x/tools/go/types/objectpath
+golang.org/x/tools/go/types/typeutil
+golang.org/x/tools/internal/aliases
+golang.org/x/tools/internal/event
+golang.org/x/tools/internal/event/core
+golang.org/x/tools/internal/event/keys
+golang.org/x/tools/internal/event/label
+golang.org/x/tools/internal/gcimporter
+golang.org/x/tools/internal/gocommand
+golang.org/x/tools/internal/packagesinternal
+golang.org/x/tools/internal/pkgbits
+golang.org/x/tools/internal/stdlib
+golang.org/x/tools/internal/typeparams
+golang.org/x/tools/internal/typesinternal
+golang.org/x/tools/internal/versions
+# gopkg.in/yaml.v3 v3.0.1
+## explicit
+gopkg.in/yaml.v3

--- a/flatpaktest/flatpak_test.go
+++ b/flatpaktest/flatpak_test.go
@@ -1,0 +1,349 @@
+//go:build integration && linux
+// +build integration,linux
+
+package flatpaktest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	appID             = "io.github.nskaggs.perfuncted"
+	branch            = "stable"
+	flathubRemoteURL  = "https://dl.flathub.org/repo/flathub.flatpakrepo"
+	commandTimeout    = 45 * time.Minute
+	builderAppID      = "org.flatpak.Builder"
+	flatpakBinaryName = "flatpak"
+)
+
+type harness struct {
+	repoRoot string
+	env      []string
+}
+
+type dbusSession struct {
+	address string
+	pid     int
+}
+
+func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping Flatpak integration test in short mode")
+	}
+
+	repoRoot := mustRepoRoot(t)
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("resolve user cache directory: %v", err)
+	}
+	testRoot := filepath.Join(cacheRoot, "perfuncted-flatpak-test")
+	manifestPath := filepath.Join(repoRoot, "io.github.nskaggs.perfuncted.yml")
+	appstreamPath := filepath.Join(repoRoot, "flatpak", "io.github.nskaggs.perfuncted.metainfo.xml")
+	bundlePath := filepath.Join(repoRoot, "dist", "flatpak", "perfuncted.flatpak")
+	buildDir := filepath.Join(repoRoot, "builddir")
+	defaultRepoDir := filepath.Join(repoRoot, "repo")
+	stateDir := filepath.Join(testRoot, "flatpak-state")
+	repoDir := filepath.Join(testRoot, "repo")
+	buildHome := filepath.Join(testRoot, "build-home")
+	bundleHome := filepath.Join(testRoot, "bundle-home")
+	tmpRoot := filepath.Join(testRoot, "tmp")
+	runRoot := filepath.Join(testRoot, "run")
+
+	// Keep the workspace clean if the test is interrupted or fails part-way through.
+	_ = os.RemoveAll(bundlePath)
+	_ = os.RemoveAll(buildDir)
+	_ = os.RemoveAll(defaultRepoDir)
+	_ = os.RemoveAll(testRoot)
+	_ = os.RemoveAll(filepath.Join(repoRoot, ".flatpak-builder"))
+	t.Cleanup(func() {
+		_ = os.RemoveAll(buildDir)
+		_ = os.RemoveAll(defaultRepoDir)
+		_ = os.RemoveAll(testRoot)
+		_ = os.RemoveAll(filepath.Join(repoRoot, ".flatpak-builder"))
+	})
+
+	if err := os.MkdirAll(testRoot, 0o755); err != nil {
+		t.Fatalf("create flatpak test root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(bundlePath), 0o755); err != nil {
+		t.Fatalf("create bundle directory: %v", err)
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("create flatpak state directory: %v", err)
+	}
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("create flatpak repo directory: %v", err)
+	}
+	if err := os.MkdirAll(tmpRoot, 0o755); err != nil {
+		t.Fatalf("create flatpak tmp directory: %v", err)
+	}
+	if err := os.MkdirAll(runRoot, 0o755); err != nil {
+		t.Fatalf("create flatpak run directory: %v", err)
+	}
+
+	session := mustStartDBusSession(t)
+	t.Cleanup(session.close)
+
+	buildHarness := newHarness(t, repoRoot, session.address, buildHome, tmpRoot, runRoot)
+	bundleHarness := newHarness(t, repoRoot, session.address, bundleHome, tmpRoot, runRoot)
+
+	buildHarness.mustRun(t, repoRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
+	buildHarness.mustRun(t, repoRoot, "install", "-y", "--user", "flathub", builderAppID)
+
+	t.Run("manifest lint", func(t *testing.T) {
+		buildHarness.mustRunLint(t, repoRoot, "manifest", manifestPath)
+		buildHarness.mustRun(t, repoRoot, "run", "--command=flatpak-builder-lint", builderAppID, "appstream", appstreamPath)
+	})
+
+	buildHarness.mustRun(t, repoRoot, "run", "--command=flathub-build", builderAppID,
+		"--install",
+		"--disable-rofiles-fuse",
+		"--repo="+repoDir,
+		"--state-dir="+stateDir,
+		manifestPath,
+	)
+
+	t.Run("installed build", func(t *testing.T) {
+		stdout, stderr, code := buildHarness.run(t, repoRoot, "run", appID, "version")
+		if code != 0 {
+			t.Fatalf("flatpak run %s version exit code = %d, want 0\nstdout=%q\nstderr=%q", appID, code, stdout, stderr)
+		}
+		assertVersionOutput(t, stdout)
+	})
+
+	t.Run("repo lint", func(t *testing.T) {
+		buildHarness.mustRunLint(t, repoRoot, "repo", repoDir)
+	})
+
+	buildHarness.mustRun(t, repoRoot, "build-bundle", repoDir, bundlePath, appID, branch)
+	if info, err := os.Stat(bundlePath); err != nil {
+		t.Fatalf("bundle missing after build: %v", err)
+	} else if info.Size() == 0 {
+		t.Fatalf("bundle is empty: %s", bundlePath)
+	}
+
+	bundleHarness.mustRun(t, repoRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
+	bundleHarness.mustRun(t, repoRoot, "install", "--user", "-y", bundlePath)
+
+	t.Run("bundle install", func(t *testing.T) {
+		stdout, stderr, code := bundleHarness.run(t, repoRoot, "run", appID, "version")
+		if code != 0 {
+			t.Fatalf("flatpak run %s version exit code = %d, want 0\nstdout=%q\nstderr=%q", appID, code, stdout, stderr)
+		}
+		assertVersionOutput(t, stdout)
+	})
+}
+
+func newHarness(t *testing.T, repoRoot, dbusAddress, home, tmpRoot, runRoot string) *harness {
+	t.Helper()
+
+	mustMkdirAll(t,
+		home,
+		filepath.Join(home, ".cache"),
+		filepath.Join(home, ".config"),
+		filepath.Join(home, ".local", "share"),
+		tmpRoot,
+		runRoot,
+	)
+
+	env := os.Environ()
+	env = setEnv(env, "HOME", home)
+	env = setEnv(env, "XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	env = setEnv(env, "XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	env = setEnv(env, "XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	env = setEnv(env, "XDG_RUNTIME_DIR", runRoot)
+	env = setEnv(env, "DBUS_SESSION_BUS_ADDRESS", dbusAddress)
+	env = setEnv(env, "TMPDIR", tmpRoot)
+	env = unsetEnv(env, "DISPLAY")
+	env = unsetEnv(env, "WAYLAND_DISPLAY")
+	env = unsetEnv(env, "SWAYSOCK")
+	env = unsetEnv(env, "XDG_SESSION_TYPE")
+
+	return &harness{
+		repoRoot: repoRoot,
+		env:      env,
+	}
+}
+
+func (h *harness) mustRun(t *testing.T, dir, subcommand string, args ...string) {
+	t.Helper()
+
+	stdout, stderr, code := h.run(t, dir, subcommand, args...)
+	if code != 0 {
+		t.Fatalf("flatpak %s %s exit code = %d, want 0\nstdout=%q\nstderr=%q", subcommand, strings.Join(args, " "), code, stdout, stderr)
+	}
+}
+
+func (h *harness) mustRunLint(t *testing.T, dir, lintMode string, args ...string) {
+	t.Helper()
+
+	stdout, stderr, code := h.run(t, dir, "run", append([]string{"--command=flatpak-builder-lint", builderAppID, lintMode}, args...)...)
+	if code == 0 {
+		return
+	}
+	if allowKnownManifestException(stdout) {
+		t.Logf("flatpak-builder-lint %s reported known Flathub policy exception; continuing", lintMode)
+		return
+	}
+	t.Fatalf("flatpak-builder-lint %s exit code = %d, want 0\nstdout=%q\nstderr=%q", lintMode, code, stdout, stderr)
+}
+
+func (h *harness) run(t *testing.T, dir, subcommand string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+
+	if _, err := exec.LookPath(flatpakBinaryName); err != nil {
+		t.Fatalf("required command %q not found in PATH: %v", flatpakBinaryName, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	fullArgs := append([]string{subcommand}, args...)
+	t.Logf("$ flatpak %s", strings.Join(fullArgs, " "))
+
+	cmd := exec.CommandContext(ctx, flatpakBinaryName, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = h.env
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	stdout = outBuf.String()
+	stderr = errBuf.String()
+
+	if err == nil {
+		return stdout, stderr, 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return stdout, stderr, exitErr.ExitCode()
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Logf("flatpak %s timed out after %s", strings.Join(fullArgs, " "), commandTimeout)
+	}
+	t.Logf("flatpak %s failed: %v\nstdout=%q\nstderr=%q", strings.Join(fullArgs, " "), err, stdout, stderr)
+	return stdout, stderr, 1
+}
+
+func mustStartDBusSession(t *testing.T) *dbusSession {
+	t.Helper()
+
+	if _, err := exec.LookPath("dbus-daemon"); err != nil {
+		t.Fatalf("required command %q not found in PATH: %v", "dbus-daemon", err)
+	}
+
+	cmd := exec.Command("dbus-daemon", "--session", "--fork", "--print-address=1", "--print-pid=1", "--nopidfile")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("start dbus session: %v\noutput=%s", err, out)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("unexpected dbus-daemon output: %q", string(out))
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(lines[1]))
+	if err != nil {
+		t.Fatalf("parse dbus-daemon pid from %q: %v", lines[1], err)
+	}
+
+	return &dbusSession{
+		address: strings.TrimSpace(lines[0]),
+		pid:     pid,
+	}
+}
+
+func (s *dbusSession) close() {
+	if s == nil || s.pid == 0 {
+		return
+	}
+	if proc, err := os.FindProcess(s.pid); err == nil {
+		_ = proc.Kill()
+	}
+}
+
+func allowKnownManifestException(stdout string) bool {
+	// Flathub treats the KDE window-management talk-name as a review exception.
+	var report struct {
+		Errors []string `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		return false
+	}
+	return len(report.Errors) == 1 && report.Errors[0] == "finish-args-kwin-talk-name"
+}
+
+func assertVersionOutput(t *testing.T, stdout string) {
+	t.Helper()
+
+	if !strings.Contains(stdout, "builtBy: flatpak") {
+		t.Fatalf("version output missing builtBy stamp: %q", stdout)
+	}
+	if !strings.Contains(stdout, "commit:") {
+		t.Fatalf("version output missing commit line: %q", stdout)
+	}
+	if !strings.Contains(stdout, "date:") {
+		t.Fatalf("version output missing date line: %q", stdout)
+	}
+}
+
+func mustRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed while resolving repository root")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	return absRoot
+}
+
+func mustMkdirAll(t *testing.T, dirs ...string) {
+	t.Helper()
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func unsetEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/flatpaktest/flatpak_test.go
+++ b/flatpaktest/flatpak_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,8 +50,9 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 		t.Fatalf("resolve user cache directory: %v", err)
 	}
 	testRoot := filepath.Join(cacheRoot, "perfuncted-flatpak-test")
-	manifestPath := filepath.Join(repoRoot, "io.github.nskaggs.perfuncted.yml")
-	appstreamPath := filepath.Join(repoRoot, "flatpak", "io.github.nskaggs.perfuncted.metainfo.xml")
+	sourceRoot := filepath.Join(testRoot, "source")
+	manifestPath := filepath.Join(sourceRoot, "io.github.nskaggs.perfuncted.yml")
+	appstreamPath := filepath.Join(sourceRoot, "flatpak", "io.github.nskaggs.perfuncted.metainfo.xml")
 	bundlePath := filepath.Join(repoRoot, "dist", "flatpak", "perfuncted.flatpak")
 	buildDir := filepath.Join(repoRoot, "builddir")
 	defaultRepoDir := filepath.Join(repoRoot, "repo")
@@ -67,15 +69,20 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	_ = os.RemoveAll(defaultRepoDir)
 	_ = os.RemoveAll(testRoot)
 	_ = os.RemoveAll(filepath.Join(repoRoot, ".flatpak-builder"))
+	_ = os.RemoveAll(sourceRoot)
 	t.Cleanup(func() {
 		_ = os.RemoveAll(buildDir)
 		_ = os.RemoveAll(defaultRepoDir)
 		_ = os.RemoveAll(testRoot)
 		_ = os.RemoveAll(filepath.Join(repoRoot, ".flatpak-builder"))
+		_ = mustRemoveWorktree(repoRoot, sourceRoot)
 	})
 
 	if err := os.MkdirAll(testRoot, 0o755); err != nil {
 		t.Fatalf("create flatpak test root: %v", err)
+	}
+	if err := mustAddWorktree(repoRoot, sourceRoot); err != nil {
+		t.Fatalf("create flatpak source worktree: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(bundlePath), 0o755); err != nil {
 		t.Fatalf("create bundle directory: %v", err)
@@ -96,18 +103,18 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	session := mustStartDBusSession(t)
 	t.Cleanup(session.close)
 
-	buildHarness := newHarness(t, repoRoot, session.address, buildHome, tmpRoot, runRoot)
-	bundleHarness := newHarness(t, repoRoot, session.address, bundleHome, tmpRoot, runRoot)
+	buildHarness := newHarness(t, sourceRoot, session.address, buildHome, tmpRoot, runRoot)
+	bundleHarness := newHarness(t, sourceRoot, session.address, bundleHome, tmpRoot, runRoot)
 
-	buildHarness.mustRun(t, repoRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
-	buildHarness.mustRun(t, repoRoot, "install", "-y", "--user", "flathub", builderAppID)
+	buildHarness.mustRun(t, sourceRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
+	buildHarness.mustRun(t, sourceRoot, "install", "-y", "--user", "flathub", builderAppID)
 
 	t.Run("manifest lint", func(t *testing.T) {
-		buildHarness.mustRunLint(t, repoRoot, "manifest", manifestPath)
-		buildHarness.mustRun(t, repoRoot, "run", "--command=flatpak-builder-lint", builderAppID, "appstream", appstreamPath)
+		buildHarness.mustRunLint(t, sourceRoot, "manifest", manifestPath)
+		buildHarness.mustRun(t, sourceRoot, "run", "--command=flatpak-builder-lint", builderAppID, "appstream", appstreamPath)
 	})
 
-	buildHarness.mustRun(t, repoRoot, "run", "--command=flathub-build", builderAppID,
+	buildHarness.mustRun(t, sourceRoot, "run", "--command=flathub-build", builderAppID,
 		"--install",
 		"--disable-rofiles-fuse",
 		"--repo="+repoDir,
@@ -116,7 +123,7 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	)
 
 	t.Run("installed build", func(t *testing.T) {
-		stdout, stderr, code := buildHarness.run(t, repoRoot, "run", appID, "version")
+		stdout, stderr, code := buildHarness.run(t, sourceRoot, "run", appID, "version")
 		if code != 0 {
 			t.Fatalf("flatpak run %s version exit code = %d, want 0\nstdout=%q\nstderr=%q", appID, code, stdout, stderr)
 		}
@@ -124,21 +131,21 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	})
 
 	t.Run("repo lint", func(t *testing.T) {
-		buildHarness.mustRunLint(t, repoRoot, "repo", repoDir)
+		buildHarness.mustRunLint(t, sourceRoot, "repo", repoDir)
 	})
 
-	buildHarness.mustRun(t, repoRoot, "build-bundle", repoDir, bundlePath, appID, branch)
+	buildHarness.mustRun(t, sourceRoot, "build-bundle", repoDir, bundlePath, appID, branch)
 	if info, err := os.Stat(bundlePath); err != nil {
 		t.Fatalf("bundle missing after build: %v", err)
 	} else if info.Size() == 0 {
 		t.Fatalf("bundle is empty: %s", bundlePath)
 	}
 
-	bundleHarness.mustRun(t, repoRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
-	bundleHarness.mustRun(t, repoRoot, "install", "--user", "-y", bundlePath)
+	bundleHarness.mustRun(t, sourceRoot, "remote-add", "--if-not-exists", "--user", "flathub", flathubRemoteURL)
+	bundleHarness.mustRun(t, sourceRoot, "install", "--user", "-y", bundlePath)
 
 	t.Run("bundle install", func(t *testing.T) {
-		stdout, stderr, code := bundleHarness.run(t, repoRoot, "run", appID, "version")
+		stdout, stderr, code := bundleHarness.run(t, sourceRoot, "run", appID, "version")
 		if code != 0 {
 			t.Fatalf("flatpak run %s version exit code = %d, want 0\nstdout=%q\nstderr=%q", appID, code, stdout, stderr)
 		}
@@ -163,8 +170,10 @@ func newHarness(t *testing.T, repoRoot, dbusAddress, home, tmpRoot, runRoot stri
 	env = setEnv(env, "XDG_CACHE_HOME", filepath.Join(home, ".cache"))
 	env = setEnv(env, "XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	env = setEnv(env, "XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	env = setEnv(env, "XDG_DATA_DIRS", "/app/share:/usr/local/share:/usr/share")
 	env = setEnv(env, "XDG_RUNTIME_DIR", runRoot)
 	env = setEnv(env, "DBUS_SESSION_BUS_ADDRESS", dbusAddress)
+	env = setEnv(env, "NO_AT_BRIDGE", "1")
 	env = setEnv(env, "TMPDIR", tmpRoot)
 	env = unsetEnv(env, "DISPLAY")
 	env = unsetEnv(env, "WAYLAND_DISPLAY")
@@ -298,6 +307,34 @@ func assertVersionOutput(t *testing.T, stdout string) {
 	if !strings.Contains(stdout, "date:") {
 		t.Fatalf("version output missing date line: %q", stdout)
 	}
+}
+
+func mustAddWorktree(repoRoot, sourceRoot string) error {
+	if _, err := os.Stat(sourceRoot); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", "--detach", sourceRoot, "HEAD")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add: %w: %s", err, out)
+	}
+	return nil
+}
+
+func mustRemoveWorktree(repoRoot, sourceRoot string) error {
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", sourceRoot)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the worktree is already gone, keep cleanup best-effort.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("git worktree remove: %w: %s", err, out)
+	}
+	return nil
 }
 
 func mustRepoRoot(t *testing.T) string {

--- a/flatpaktest/flatpak_test.go
+++ b/flatpaktest/flatpak_test.go
@@ -25,7 +25,6 @@ const (
 	commandTimeout    = 45 * time.Minute
 	builderAppID      = "org.flatpak.Builder"
 	flatpakBinaryName = "flatpak"
-	flatpakHelperPath = "/usr/libexec/flatpak-session-helper"
 	flatpakService    = "org.freedesktop.Flatpak.service"
 )
 
@@ -351,16 +350,35 @@ func mustWriteFlatpakServiceFile(dbusHome string) error {
 	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
 		return fmt.Errorf("create flatpak D-Bus service directory: %w", err)
 	}
-	if _, err := os.Stat(flatpakHelperPath); err != nil {
-		return fmt.Errorf("required command %q not found: %w", flatpakHelperPath, err)
+	helperPath, err := resolveFlatpakSessionHelper()
+	if err != nil {
+		return err
 	}
 
 	servicePath := filepath.Join(serviceDir, flatpakService)
-	service := fmt.Sprintf("[D-BUS Service]\nName=org.freedesktop.Flatpak\nExec=%s\nSystemdService=flatpak-session-helper.service\n", flatpakHelperPath)
+	service := fmt.Sprintf("[D-BUS Service]\nName=org.freedesktop.Flatpak\nExec=%s\nSystemdService=flatpak-session-helper.service\n", helperPath)
 	if err := os.WriteFile(servicePath, []byte(service), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", servicePath, err)
 	}
 	return nil
+}
+
+func resolveFlatpakSessionHelper() (string, error) {
+	if path, err := exec.LookPath("flatpak-session-helper"); err == nil {
+		return path, nil
+	}
+
+	for _, candidate := range []string{
+		"/usr/libexec/flatpak-session-helper",
+		"/usr/lib/flatpak-session-helper",
+		"/usr/libexec/flatpak-system-helper",
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("required Flatpak session helper not found in PATH or common install locations")
 }
 
 func mustRepoRoot(t *testing.T) string {

--- a/flatpaktest/flatpak_test.go
+++ b/flatpaktest/flatpak_test.go
@@ -316,7 +316,7 @@ func mustAddWorktree(repoRoot, sourceRoot string) error {
 		return err
 	}
 
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", "--detach", sourceRoot, "HEAD")
+	cmd := exec.Command("git", "-c", "safe.directory="+repoRoot, "-C", repoRoot, "worktree", "add", "--detach", sourceRoot, "HEAD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git worktree add: %w: %s", err, out)
@@ -325,7 +325,7 @@ func mustAddWorktree(repoRoot, sourceRoot string) error {
 }
 
 func mustRemoveWorktree(repoRoot, sourceRoot string) error {
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", sourceRoot)
+	cmd := exec.Command("git", "-c", "safe.directory="+repoRoot, "-C", repoRoot, "worktree", "remove", "--force", sourceRoot)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// If the worktree is already gone, keep cleanup best-effort.

--- a/flatpaktest/flatpak_test.go
+++ b/flatpaktest/flatpak_test.go
@@ -25,6 +25,8 @@ const (
 	commandTimeout    = 45 * time.Minute
 	builderAppID      = "org.flatpak.Builder"
 	flatpakBinaryName = "flatpak"
+	flatpakHelperPath = "/usr/libexec/flatpak-session-helper"
+	flatpakService    = "org.freedesktop.Flatpak.service"
 )
 
 type harness struct {
@@ -60,6 +62,7 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	repoDir := filepath.Join(testRoot, "repo")
 	buildHome := filepath.Join(testRoot, "build-home")
 	bundleHome := filepath.Join(testRoot, "bundle-home")
+	dbusHome := filepath.Join(testRoot, "dbus-home")
 	tmpRoot := filepath.Join(testRoot, "tmp")
 	runRoot := filepath.Join(testRoot, "run")
 
@@ -81,6 +84,9 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 	if err := os.MkdirAll(testRoot, 0o755); err != nil {
 		t.Fatalf("create flatpak test root: %v", err)
 	}
+	if err := mustWriteFlatpakServiceFile(dbusHome); err != nil {
+		t.Fatalf("write flatpak D-Bus service file: %v", err)
+	}
 	if err := mustAddWorktree(repoRoot, sourceRoot); err != nil {
 		t.Fatalf("create flatpak source worktree: %v", err)
 	}
@@ -100,7 +106,7 @@ func TestFlatpakBundleBuildInstallAndRun(t *testing.T) {
 		t.Fatalf("create flatpak run directory: %v", err)
 	}
 
-	session := mustStartDBusSession(t)
+	session := mustStartDBusSession(t, dbusHome)
 	t.Cleanup(session.close)
 
 	buildHarness := newHarness(t, sourceRoot, session.address, buildHome, tmpRoot, runRoot)
@@ -247,7 +253,7 @@ func (h *harness) run(t *testing.T, dir, subcommand string, args ...string) (std
 	return stdout, stderr, 1
 }
 
-func mustStartDBusSession(t *testing.T) *dbusSession {
+func mustStartDBusSession(t *testing.T, dbusHome string) *dbusSession {
 	t.Helper()
 
 	if _, err := exec.LookPath("dbus-daemon"); err != nil {
@@ -255,6 +261,9 @@ func mustStartDBusSession(t *testing.T) *dbusSession {
 	}
 
 	cmd := exec.Command("dbus-daemon", "--session", "--fork", "--print-address=1", "--print-pid=1", "--nopidfile")
+	cmd.Env = os.Environ()
+	cmd.Env = setEnv(cmd.Env, "HOME", dbusHome)
+	cmd.Env = setEnv(cmd.Env, "XDG_DATA_HOME", filepath.Join(dbusHome, ".local", "share"))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("start dbus session: %v\noutput=%s", err, out)
@@ -333,6 +342,23 @@ func mustRemoveWorktree(repoRoot, sourceRoot string) error {
 			return nil
 		}
 		return fmt.Errorf("git worktree remove: %w: %s", err, out)
+	}
+	return nil
+}
+
+func mustWriteFlatpakServiceFile(dbusHome string) error {
+	serviceDir := filepath.Join(dbusHome, ".local", "share", "dbus-1", "services")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		return fmt.Errorf("create flatpak D-Bus service directory: %w", err)
+	}
+	if _, err := os.Stat(flatpakHelperPath); err != nil {
+		return fmt.Errorf("required command %q not found: %w", flatpakHelperPath, err)
+	}
+
+	servicePath := filepath.Join(serviceDir, flatpakService)
+	service := fmt.Sprintf("[D-BUS Service]\nName=org.freedesktop.Flatpak\nExec=%s\nSystemdService=flatpak-session-helper.service\n", flatpakHelperPath)
+	if err := os.WriteFile(servicePath, []byte(service), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", servicePath, err)
 	}
 	return nil
 }

--- a/io.github.nskaggs.perfuncted.yml
+++ b/io.github.nskaggs.perfuncted.yml
@@ -1,0 +1,113 @@
+app-id: io.github.nskaggs.perfuncted
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
+command: pf
+default-branch: stable
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=all
+  - --talk-name=org.gnome.Shell
+  - --talk-name=org.kde.KWin
+modules:
+  - name: perfuncted
+    buildsystem: simple
+    build-options:
+      env:
+        CGO_ENABLED: '0'
+        GOROOT: /usr/lib/sdk/golang
+    build-commands:
+      - ${GOROOT}/bin/go build -mod=vendor -trimpath -buildvcs=false -ldflags "-s -w -X main.builtBy=flatpak" -o "${FLATPAK_DEST}/bin/pf" ./cmd/pf
+      - install -Dm0644 LICENSE "${FLATPAK_DEST}/share/licenses/${FLATPAK_ID}/perfuncted/LICENSE"
+      - install -Dm0644 flatpak/io.github.nskaggs.perfuncted.metainfo.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
+      - install -Dm0644 flatpak/io.github.nskaggs.perfuncted.svg "${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg"
+    sources:
+      - type: dir
+        path: .
+      - dest: vendor
+        path: flatpak/modules.txt
+        type: file
+      - dest: vendor/github.com/bendahl/uinput
+        sha256: 47e8cde78bceb3d0016ff1d25a8547aa2e3ac28d2ae28870d83531250671e4eb
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/bendahl/uinput/@v/v1.7.0.zip
+      - dest: vendor/github.com/godbus/dbus/v5
+        sha256: 5c6f37c725a481fb0f1e7866ae273429525d8cc6a6cace87da28e53370f5596a
+        strip-components: 4
+        type: archive
+        url: https://proxy.golang.org/github.com/godbus/dbus/v5/@v/v5.2.2.zip
+      - dest: vendor/github.com/jezek/xgb
+        sha256: e8a10b7ebf84cc72435c9c8f33e459fb5872195bc714124af2beb1752c355d9c
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/jezek/xgb/@v/v1.3.0.zip
+      - dest: vendor/github.com/spf13/cobra
+        sha256: a00aae6fcd631e0fde52c98604452ff70e1b73c3b8a560d68db15aff5e26872d
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/spf13/cobra/@v/v1.10.2.zip
+      - dest: vendor/go.uber.org/goleak
+        sha256: 70edef0ce7d830d992f024e527fd3452069b884f94a27787a718bd68dd620702
+        strip-components: 2
+        type: archive
+        url: https://proxy.golang.org/go.uber.org/goleak/@v/v1.3.0.zip
+      - dest: vendor/golang.org/x/sys
+        sha256: cb8b073934cf7e579c9f80c4d12619d5f96fcf97af6f07fdc649e7acec0aaddf
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/golang.org/x/sys/@v/v0.43.0.zip
+      - dest: vendor/golang.org/x/tools
+        sha256: e92174a8ef7a2e0e5f3779989f78a3d32fc75081296446ffaac81b91636794da
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/golang.org/x/tools/@v/v0.44.0.zip
+      - dest: vendor/gopkg.in/yaml.v3
+        sha256: aab8fbc4e6300ea08e6afe1caea18a21c90c79f489f52c53e2f20431f1a9a015
+        strip-components: 2
+        type: archive
+        url: https://proxy.golang.org/gopkg.in/yaml.v3/@v/v3.0.1.zip
+      - dest: vendor/github.com/cpuguy83/go-md2man/v2
+        sha256: b8059316e38bcfd28b69d2c2b32d34b9e800ccaa1ff4b5a61022cbe98fa7c710
+        strip-components: 4
+        type: archive
+        url: https://proxy.golang.org/github.com/cpuguy83/go-md2man/v2/@v/v2.0.6.zip
+      - dest: vendor/github.com/inconshreveable/mousetrap
+        sha256: 526674de624d7db108cfe7653ef110ccdfd97bc85026254224815567928ed243
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/inconshreveable/mousetrap/@v/v1.1.0.zip
+      - dest: vendor/github.com/kr/text
+        sha256: 368eb318f91a5b67be905c47032ab5c31a1d49a97848b1011a0d0a2122b30ba4
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/kr/text/@v/v0.2.0.zip
+      - dest: vendor/github.com/russross/blackfriday/v2
+        sha256: 7852750d58a053ce38b01f2c203208817564f552ebf371b2b630081d7004c6ae
+        strip-components: 4
+        type: archive
+        url: https://proxy.golang.org/github.com/russross/blackfriday/v2/@v/v2.1.0.zip
+      - dest: vendor/github.com/spf13/pflag
+        sha256: 83910188d8735f84a48a80ab78351edac0b569896f2b3a244c696a07da9aa5ed
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/github.com/spf13/pflag/@v/v1.0.9.zip
+      - dest: vendor/go.yaml.in/yaml/v3
+        sha256: 0317dae56eaa9e9954467c8768fd6a89ba2005f1534e2c26fce5163ad8d2ef31
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/go.yaml.in/yaml/v3/@v/v3.0.4.zip
+      - dest: vendor/golang.org/x/mod
+        sha256: 6a64c84837167aa92a5dd55aa318351b8c45623b2fb80804cce704e72a9621c8
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/golang.org/x/mod/@v/v0.35.0.zip
+      - dest: vendor/golang.org/x/sync
+        sha256: 7179d4d68800f6fdcadb9d4bbf11cbb5df9b40360c89305c203fe20723cbd375
+        strip-components: 3
+        type: archive
+        url: https://proxy.golang.org/golang.org/x/sync/@v/v0.20.0.zip

--- a/justfile
+++ b/justfile
@@ -129,6 +129,10 @@ test-integration-nested-wayland-debug:
 test-integration: test-integration-headless-x11 test-integration-headless-wayland
     CGO_ENABLED=0 go test -tags=integration ./window ./input ./screen ./clipboard -count=1
 
+# Build, install, and validate the Flatpak bundle in an isolated Flatpak home.
+test-flatpak:
+    CGO_ENABLED=0 go test -tags=integration ./flatpaktest -count=1 -v -timeout=60m
+
 # Run all test suites: unit + session + integration
 test-all: test-unit test-session test-integration
     @echo "Completed test-all"


### PR DESCRIPTION
This PR switches the Flatpak work from Flathub publishing to a bundle-first flow:

- adds a real Flatpak manifest at the repo root
- builds and validates a Flatpak bundle in CI
- uploads `dist/flatpak/perfuncted.flatpak` as a GitHub artifact
- adds an integration test that installs and smoke-tests the bundle
- updates the README and `just` workflow for local bundle validation

Notes:
- Flathub publishing is intentionally deferred for now
- the manifest lint still carries the KDE talk-name exception expected for Flathub review

Checks run locally:
- `go test -tags=integration ./flatpaktest -run TestFlatpakBundleBuildInstallAndRun -count=1 -v -timeout=60m`
- `go test ./...`
- `git diff --check`