### PR TITLE
Fix polling panics and capture bounds regressions

### DIFF
--- a/cmd/pf/root.go
+++ b/cmd/pf/root.go
@@ -525,6 +525,9 @@ Runs until --duration expires or Ctrl+C.`,
 			if err != nil {
 				return err
 			}
+			if poll <= 0 {
+				poll = 100 * time.Millisecond
+			}
 			dur, err := parseDuration(watchDurFlag, 0)
 			if err != nil {
 				return err
@@ -1260,6 +1263,9 @@ func printWindowListPlain(wins []window.Info) {
 }
 
 func waitForWindowMatch(ctx context.Context, m window.Manager, match window.Match, poll time.Duration) (window.Info, error) {
+	if poll <= 0 {
+		poll = 100 * time.Millisecond
+	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 
@@ -1280,6 +1286,9 @@ func waitForWindowMatch(ctx context.Context, m window.Manager, match window.Matc
 }
 
 func waitForWindowCloseMatch(ctx context.Context, m window.Manager, match window.Match, poll time.Duration) error {
+	if poll <= 0 {
+		poll = 100 * time.Millisecond
+	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 
@@ -1954,6 +1963,9 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			}
 			if len(rects) != len(wants) {
 				return fmt.Errorf("len(rects)=%d != len(wants)=%d", len(rects), len(wants))
+			}
+			if len(rects) == 0 {
+				return fmt.Errorf("scan-for requires at least one rect/hash pair")
 			}
 			poll, err := parseDuration(pollFlag, 50*time.Millisecond)
 			if err != nil {

--- a/cmd/pf/root_test.go
+++ b/cmd/pf/root_test.go
@@ -180,6 +180,24 @@ func TestWindowCommands(t *testing.T) {
 			t.Fatalf("stdout = %q, want empty", stdout)
 		}
 	})
+
+	t.Run("wait-close zero poll", func(t *testing.T) {
+		mgr := &pftest.Manager{Lists: [][]window.Info{
+			{{ID: 11, Title: "Firefox", AppID: "firefox", PID: 42}},
+			{},
+		}}
+		stdout, stderr, code := captureRunIO(t, []string{"window", "wait-close", "title:Firefox", "--poll", "0s", "--timeout", "250ms"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(nil, nil, mgr, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if stdout != "" {
+			t.Fatalf("stdout = %q, want empty", stdout)
+		}
+	})
 }
 
 func TestScreenAndInputCommands(t *testing.T) {
@@ -227,6 +245,20 @@ func TestScreenAndInputCommands(t *testing.T) {
 		}
 		if _, err := strconv.ParseUint(strings.TrimSpace(stdout), 16, 32); err != nil {
 			t.Fatalf("stdout = %q, want 8-digit hex hash: %v", stdout, err)
+		}
+	})
+
+	t.Run("scan-for empty", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"find", "scan-for", "--rects", "", "--wants", ""}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(&pftest.Screenshotter{Width: 2, Height: 2}, nil, nil, nil), nil
+			}
+		})
+		if code == 0 {
+			t.Fatalf("exit code = 0, want non-zero; stdout=%q stderr=%q", stdout, stderr)
+		}
+		if !strings.Contains(stderr, "scan-for requires at least one rect/hash pair") {
+			t.Fatalf("stderr = %q, want empty-input error", stderr)
 		}
 	})
 

--- a/find/find.go
+++ b/find/find.go
@@ -51,6 +51,13 @@ func adaptivePoll(attempt int, base, max time.Duration) time.Duration {
 // into wait loops in a follow-up commit.
 var _ = adaptivePoll
 
+func clampPoll(poll time.Duration) time.Duration {
+	if poll <= 0 {
+		return 10 * time.Millisecond
+	}
+	return poll
+}
+
 // PixelHash computes a 32-bit hash of all RGBA pixels in img.
 // For *image.RGBA images it uses a fast path that reads pixel bytes directly
 // from the underlying Pix slice, avoiding per-pixel interface calls and
@@ -151,7 +158,7 @@ func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want u
 	}
 
 	// Fixed-interval polling.
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -203,7 +210,7 @@ func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, 
 	}
 
 	// Fixed-interval polling.
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -308,7 +315,7 @@ func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Recta
 	}
 
 	// Fixed-interval polling.
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -367,6 +374,9 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 	if len(rects) != len(wants) {
 		return Result{}, fmt.Errorf("find: ScanFor: len(rects)=%d != len(wants)=%d", len(rects), len(wants))
 	}
+	if len(rects) == 0 {
+		return Result{}, fmt.Errorf("find: ScanFor: no regions provided")
+	}
 
 	// Compute union bounding box and total individual area.
 	bbox := rects[0]
@@ -378,7 +388,7 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 	bboxArea := bbox.Dx() * bbox.Dy()
 	useBbox := bboxArea <= 2*totalArea
 
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -388,6 +398,7 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 			if err != nil {
 				return Result{}, err
 			}
+			imgBase := img.Bounds().Min
 			sub, ok := img.(interface {
 				SubImage(image.Rectangle) image.Image
 			})
@@ -395,12 +406,14 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 				useBbox = false // fall back if SubImage unavailable
 			} else {
 				for i, rect := range rects {
-					// Translate rect to grabbed image coordinate space.
+					// Translate the requested screen rect into the grabbed image's
+					// coordinate space. Backends may return either zero-origin or
+					// absolute-bounds images, so respect the returned bounds.
 					tr := image.Rect(
-						rect.Min.X-bbox.Min.X,
-						rect.Min.Y-bbox.Min.Y,
-						rect.Max.X-bbox.Min.X,
-						rect.Max.Y-bbox.Min.Y,
+						rect.Min.X-bbox.Min.X+imgBase.X,
+						rect.Min.Y-bbox.Min.Y+imgBase.Y,
+						rect.Max.X-bbox.Min.X+imgBase.X,
+						rect.Max.Y-bbox.Min.Y+imgBase.Y,
 					)
 					h := PixelHash(sub.SubImage(tr), newHash)
 					if h == wants[i] {
@@ -564,7 +577,7 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 		refFirst = color.RGBAModel.Convert(reference.At(rb.Min.X, rb.Min.Y)).(color.RGBA)
 	}
 
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -700,7 +713,7 @@ func abs(x int) int {
 // via exact pixel matching, or ctx expires. Returns the absolute rectangle
 // where the reference was located.
 func WaitForLocate(ctx context.Context, sc Screenshotter, searchArea image.Rectangle, reference image.Image, poll time.Duration) (image.Rectangle, error) {
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -721,7 +734,7 @@ func WaitForLocate(ctx context.Context, sc Screenshotter, searchArea image.Recta
 // iteration and may inspect it with any predicate (brightness, color
 // presence, histogram, etc.).
 func WaitForFn(ctx context.Context, sc Screenshotter, rect image.Rectangle, fn func(image.Image) bool, poll time.Duration) (image.Image, error) {
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {

--- a/find/find_wait_test.go
+++ b/find/find_wait_test.go
@@ -203,6 +203,19 @@ func TestWaitForFn_Timeout(t *testing.T) {
 	}
 }
 
+func TestWaitForFnZeroPoll(t *testing.T) {
+	sc := &solidScreenshotter{}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := WaitForFn(ctx, sc, image.Rect(0, 0, 10, 10), func(image.Image) bool {
+		return false
+	}, 0)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
 // TestGrabHash tests the GrabHash utility function.
 func TestGrabHash_Success(t *testing.T) {
 	sc := &solidScreenshotter{}
@@ -333,6 +346,13 @@ func TestScanFor(t *testing.T) {
 	}
 }
 
+func TestScanForEmpty(t *testing.T) {
+	_, err := ScanFor(context.Background(), &solidScreenshotter{}, nil, nil, 10*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected error for empty ScanFor input")
+	}
+}
+
 // TestWaitWithTolerance tests WaitWithTolerance.
 func TestWaitWithTolerance(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
@@ -363,6 +383,30 @@ func TestWaitWithTolerance(t *testing.T) {
 	}
 	if resultRect.Min.X != 4 || resultRect.Min.Y != 4 {
 		t.Fatalf("WaitWithTolerance returned rect %v, want around (4,4)", resultRect)
+	}
+}
+
+func TestWaitWithToleranceZeroPoll(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: 100, G: 100, B: 100, A: 255})
+		}
+	}
+	ref := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			ref.SetRGBA(x, y, color.RGBA{R: 150, G: 150, B: 150, A: 255})
+		}
+	}
+
+	sc := &fakeScreen{img: img}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := WaitWithTolerance(ctx, sc, image.Rect(4, 4, 6, 6), ref, 2, 0, nil)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
 	}
 }
 
@@ -420,6 +464,30 @@ func TestWaitForLocate(t *testing.T) {
 	}
 	if found.Min.X != 5 || found.Min.Y != 7 {
 		t.Fatalf("WaitForLocate returned (%d,%d), want (5,7)", found.Min.X, found.Min.Y)
+	}
+}
+
+func TestWaitForLocateZeroPoll(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	for y := 0; y < 20; y++ {
+		for x := 0; x < 20; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: 100, G: 100, B: 100, A: 255})
+		}
+	}
+	needle := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	for y := 0; y < 3; y++ {
+		for x := 0; x < 3; x++ {
+			needle.SetRGBA(x, y, color.RGBA{R: 200, G: 0, B: 0, A: 255})
+		}
+	}
+
+	sc := &fakeScreen{img: img}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := WaitForLocate(ctx, sc, image.Rect(0, 0, 20, 20), needle, 0)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
 	}
 }
 

--- a/perfuncted.go
+++ b/perfuncted.go
@@ -270,6 +270,9 @@ func (p *Perfuncted) Close() error {
 }
 
 func Retry(ctx context.Context, poll time.Duration, fn func() error) error {
+	if poll <= 0 {
+		poll = 10 * time.Millisecond
+	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 

--- a/perfuncted_test.go
+++ b/perfuncted_test.go
@@ -230,6 +230,23 @@ func TestBundleMethodsPropagateContext(t *testing.T) {
 	}
 }
 
+func TestRetryZeroPoll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	calls := 0
+	err := perfuncted.Retry(ctx, 0, func() error {
+		calls++
+		return errors.New("try again")
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if calls == 0 {
+		t.Fatal("expected retry function to be called")
+	}
+}
+
 func TestCloseJoinsErrors(t *testing.T) {
 	t.Parallel()
 	screenErr := errors.New("screen close failed")

--- a/screen/pixels.go
+++ b/screen/pixels.go
@@ -41,7 +41,7 @@ func decodeBGRARect(data []byte, w, h, stride int, rect image.Rectangle) *image.
 	if r.Empty() {
 		return image.NewRGBA(image.Rect(0, 0, 0, 0))
 	}
-	out := image.NewRGBA(image.Rect(0, 0, r.Dx(), r.Dy()))
+	out := image.NewRGBA(r)
 	rowBytes := r.Dx() * 4
 	for y := 0; y < r.Dy(); y++ {
 		srcRow := data[(r.Min.Y+y)*stride+r.Min.X*4 : (r.Min.Y+y)*stride+r.Min.X*4+rowBytes]

--- a/screen/pixels_test.go
+++ b/screen/pixels_test.go
@@ -118,12 +118,12 @@ func TestDecodeBGRARect(t *testing.T) {
 	rect := image.Rect(1, 1, 3, 3)
 	img := decodeBGRARect(data, 3, 3, 12, rect)
 
-	if img.Bounds().Dx() != 2 || img.Bounds().Dy() != 2 {
-		t.Fatalf("expected 2x2, got %dx%d", img.Bounds().Dx(), img.Bounds().Dy())
+	if got := img.Bounds(); got != rect {
+		t.Fatalf("expected bounds %v, got %v", rect, got)
 	}
 
-	// Check (0, 0) of cropped, which is (1, 1) in original = index 4
-	c0 := img.RGBAAt(0, 0)
+	// Check (1, 1) of cropped/original = index 4.
+	c0 := img.RGBAAt(1, 1)
 	expectedB := byte(5)
 	expectedG := byte(10)
 	expectedR := byte(15)
@@ -144,16 +144,16 @@ func TestDecodeBGRARectWithStridePadding(t *testing.T) {
 	rect := image.Rect(1, 0, 2, 2)
 	img := decodeBGRARect(data, 2, 2, 12, rect)
 
-	if img.Bounds().Dx() != 1 || img.Bounds().Dy() != 2 {
-		t.Fatalf("expected 1x2, got %dx%d", img.Bounds().Dx(), img.Bounds().Dy())
+	if got := img.Bounds(); got != rect {
+		t.Fatalf("expected bounds %v, got %v", rect, got)
 	}
 
-	c0 := img.RGBAAt(0, 0)
+	c0 := img.RGBAAt(1, 0)
 	if c0.B != 0x11 || c0.G != 0x12 || c0.R != 0x13 {
 		t.Errorf("row 0: got RGB(%02x,%02x,%02x) want (13,12,11)", c0.R, c0.G, c0.B)
 	}
 
-	c1 := img.RGBAAt(0, 1)
+	c1 := img.RGBAAt(1, 1)
 	if c1.B != 0x14 || c1.G != 0x15 || c1.R != 0x16 {
 		t.Errorf("row 1: got RGB(%02x,%02x,%02x) want (16,15,14)", c1.R, c1.G, c1.B)
 	}

--- a/window/find.go
+++ b/window/find.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+func clampPoll(poll time.Duration) time.Duration {
+	if poll <= 0 {
+		return 10 * time.Millisecond
+	}
+	return poll
+}
+
 // Find returns the first window matching match.
 func Find(ctx context.Context, m Manager, match Match) (Info, error) {
 	return find(ctx, m, match, match.String())
@@ -36,7 +43,7 @@ func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration)
 
 // WaitForMatch blocks until a window matching match is found, or ctx expires.
 func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duration) (Info, error) {
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
@@ -59,7 +66,7 @@ func WaitForClose(ctx context.Context, m Manager, pattern string, poll time.Dura
 
 // WaitForMatchClose blocks until no window matches match, or ctx expires.
 func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Duration) error {
-	ticker := time.NewTicker(poll)
+	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {

--- a/window/find_test.go
+++ b/window/find_test.go
@@ -5,6 +5,7 @@ import (
 	"iter"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeManager implements Manager for testing FindByTitle.
@@ -57,5 +58,27 @@ func TestFindByTitle_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "window: not found") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestWaitForMatchZeroPoll(t *testing.T) {
+	m := &fakeManager{}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := WaitForMatch(ctx, m, Match{TitleContains: "hello"}, 0)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestWaitForMatchCloseZeroPoll(t *testing.T) {
+	m := &fakeManager{wins: []Info{{ID: 1, Title: "Hello World"}}}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := WaitForMatchClose(ctx, m, Match{TitleContains: "hello"}, 0)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
 	}
 }


### PR DESCRIPTION
This fixes the safety regressions from the review:\n\n- preserve absolute bounds for BGRA sub-rectangle decoding\n- make ScanFor work with zero-origin and absolute-bounds captures\n- clamp zero/negative poll intervals in wait loops and CLI wrappers\n- add regressions for empty ScanFor input and zero-poll waits\n\nVerified with:\n- go test ./...\n- go test -race -short ./...\n- PF_TEST_DISPLAY_SERVER=headless-wayland go test -tags=integration -timeout=90s ./integration -count=1 -run TestIntegration