### PR TITLE
Harden CLI/library sync and search coverage

### DIFF
--- a/cmd/pf/root.go
+++ b/cmd/pf/root.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -405,7 +406,7 @@ func screenCmd(openPF func() (*perfuncted.Perfuncted, error), cfg *cliConfig) *c
 			if err != nil {
 				return err
 			}
-			fmt.Println(h)
+			fmt.Printf("%08x\n", h)
 			return nil
 		},
 	}
@@ -543,6 +544,7 @@ Runs until --duration expires or Ctrl+C.`,
 			// Cancel on Ctrl+C as well.
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			defer signal.Stop(sigCh)
 			go func() {
 				select {
 				case <-sigCh:
@@ -564,7 +566,7 @@ Runs until --duration expires or Ctrl+C.`,
 					return nil
 				default:
 				}
-				h, err := pf.Screen.GrabRegionHash(context.Background(), r)
+				h, err := pf.Screen.GrabRegionHash(ctx, r)
 				if err != nil {
 					return err
 				}
@@ -1664,8 +1666,10 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error), cfg *cliConfig) *c
 			_, err = pf.Window.FindByTitle(context.Background(), args[0])
 			if err == nil {
 				fmt.Println("true")
-			} else {
+			} else if errors.Is(err, window.ErrWindowNotFound) {
 				fmt.Println("false")
+			} else {
+				return err
 			}
 			return nil
 		},
@@ -1685,13 +1689,14 @@ func windowCmd(openPF func() (*perfuncted.Perfuncted, error), cfg *cliConfig) *c
 			defer ticker.Stop()
 			var last string
 			enc := json.NewEncoder(cmd.OutOrStdout())
+			ctx := cmd.Context()
 			for {
 				select {
-				case <-cmd.Context().Done():
+				case <-ctx.Done():
 					return nil
 				case <-ticker.C:
 				}
-				wins, err := pf.Window.List(context.Background())
+				wins, err := pf.Window.List(ctx)
 				if err != nil {
 					return err
 				}
@@ -2038,10 +2043,10 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 			return nil
 		},
 	}
-	waitForVisibleChange.Flags().StringVar(&vfRect, "rect", "0,0,100,100", "x0,y0,x1,y1 (default 0,0,100,100)")
+	waitForVisibleChange.Flags().StringVar(&vfRect, "rect", "0,0,100,100", "x0,y0,x1,y1")
 	waitForVisibleChange.Flags().StringVar(&vfPoll, "poll", "50ms", "poll interval")
 	waitForVisibleChange.Flags().StringVar(&vfTimeout, "timeout", "5s", "timeout duration")
-	waitForVisibleChange.Flags().IntVar(&vfStable, "stable", 3, "consecutive identical samples required (default 3)")
+	waitForVisibleChange.Flags().IntVar(&vfStable, "stable", 3, "consecutive identical samples required")
 
 	var colorRectFlag, colorTargetFlag string
 	var colorTolerance int
@@ -2075,7 +2080,7 @@ starts (e.g. navigation begins), then wait-for-no-change to detect when it finis
 	findColor.Flags().IntVar(&colorTolerance, "tolerance", 0, "per-channel tolerance (0-255)")
 	_ = findColor.MarkFlagRequired("color")
 
-	cmd.AddCommand(findColor)
+	cmd.AddCommand(findColor, waitForVisibleChange)
 	return cmd
 }
 

--- a/cmd/pf/root_test.go
+++ b/cmd/pf/root_test.go
@@ -3,17 +3,21 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/nskaggs/perfuncted"
+	"github.com/nskaggs/perfuncted/output"
 	"github.com/nskaggs/perfuncted/pftest"
 	"github.com/nskaggs/perfuncted/window"
+	"github.com/spf13/cobra"
 )
 
 func TestNewRootCmdConfiguresCobra(t *testing.T) {
@@ -36,6 +40,8 @@ func TestNewRootCmdConfiguresCobra(t *testing.T) {
 		"input":     true,
 		"window":    true,
 		"find":      true,
+		"output":    true,
+		"run":       true,
 		"clipboard": true,
 		"info":      true,
 		"session":   true,
@@ -47,6 +53,45 @@ func TestNewRootCmdConfiguresCobra(t *testing.T) {
 	}
 	if len(wantSubs) != 0 {
 		t.Fatalf("missing subcommands: %v", wantSubs)
+	}
+}
+
+func findCommandPath(cmd *cobra.Command, path ...string) *cobra.Command {
+	if len(path) == 0 {
+		return cmd
+	}
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == path[0] {
+			return findCommandPath(sub, path[1:]...)
+		}
+	}
+	return nil
+}
+
+func TestCLICommandTreeIncludesUniqueFeatures(t *testing.T) {
+	root := newRootCmd(func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+		return func() (*perfuncted.Perfuncted, error) { return nil, nil }
+	})
+
+	for _, path := range [][]string{
+		{"screen", "hash"},
+		{"screen", "grab-region"},
+		{"screen", "get-all-pixels"},
+		{"screen", "watch"},
+		{"find", "wait-for-visible-change"},
+		{"window", "get-geometry"},
+		{"window", "is-visible"},
+		{"window", "watch"},
+		{"output", "list"},
+		{"run"},
+		{"info"},
+		{"session"},
+		{"clipboard", "get"},
+		{"clipboard", "set"},
+	} {
+		if got := findCommandPath(root, path...); got == nil {
+			t.Fatalf("missing command path %q", strings.Join(path, " "))
+		}
 	}
 }
 
@@ -292,6 +337,194 @@ func TestScreenAndInputCommands(t *testing.T) {
 		}
 		if stdout != "" {
 			t.Fatalf("stdout = %q, want empty", stdout)
+		}
+	})
+}
+
+func TestScreenHashAndWatch(t *testing.T) {
+	t.Run("hash", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"screen", "hash", "--rect", "0,0,2,2"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				img := pftest.SolidImage(2, 2, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+				return pftest.New(&pftest.Screenshotter{Frames: []image.Image{img}}, nil, nil, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if _, err := strconv.ParseUint(strings.TrimSpace(stdout), 16, 32); err != nil {
+			t.Fatalf("stdout = %q, want 8-digit hex hash: %v", stdout, err)
+		}
+	})
+
+	t.Run("watch json", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"screen", "watch", "--rect", "0,0,2,2", "--poll", "1ms", "--duration", "20ms", "--output", "json"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				img := pftest.SolidImage(2, 2, color.RGBA{R: 4, G: 5, B: 6, A: 255})
+				return pftest.New(&pftest.Screenshotter{Frames: []image.Image{img}}, nil, nil, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if !strings.Contains(stdout, `"event":"initial"`) {
+			t.Fatalf("stdout = %q, want initial JSON event", stdout)
+		}
+	})
+}
+
+func TestFindWaitForVisibleChange(t *testing.T) {
+	initial := pftest.SolidImage(2, 2, color.RGBA{A: 255})
+	changed := pftest.SolidImage(2, 2, color.RGBA{R: 200, G: 20, B: 10, A: 255})
+	stdout, stderr, code := captureRunIO(t, []string{"find", "wait-for-visible-change", "--rect", "0,0,2,2", "--poll", "1ms", "--timeout", "50ms"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+		return func() (*perfuncted.Perfuncted, error) {
+			return pftest.New(&pftest.Screenshotter{Frames: []image.Image{initial, changed}}, nil, nil, nil), nil
+		}
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+	}
+	if _, err := strconv.ParseUint(strings.TrimSpace(stdout), 16, 32); err != nil {
+		t.Fatalf("stdout = %q, want 8-digit hex hash: %v", stdout, err)
+	}
+}
+
+func TestWindowGeometryAndVisibility(t *testing.T) {
+	mgr := &pftest.Manager{Lists: [][]window.Info{{{ID: 7, Title: "Firefox", AppID: "firefox", X: 10, Y: 20, W: 100, H: 200}}}}
+
+	t.Run("geometry", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"window", "get-geometry", "Firefox"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(nil, nil, mgr, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if got, want := strings.TrimSpace(stdout), "10,20,110,220"; got != want {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("visible", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"window", "is-visible", "Firefox"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(nil, nil, mgr, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if got, want := strings.TrimSpace(stdout), "true"; got != want {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("not-found", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"window", "is-visible", "Terminal"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(nil, nil, mgr, nil), nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		if got, want := strings.TrimSpace(stdout), "false"; got != want {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("backend error", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"window", "is-visible", "Firefox"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return pftest.New(nil, nil, &pftest.Manager{Err: errors.New("boom")}, nil), nil
+			}
+		})
+		if code == 0 {
+			t.Fatalf("exit code = 0, want non-zero; stdout=%q stderr=%q", stdout, stderr)
+		}
+		if !strings.Contains(stderr, "boom") {
+			t.Fatalf("stderr = %q, want backend error", stderr)
+		}
+	})
+}
+
+type fakeOutputLister struct {
+	infos []output.Info
+}
+
+func (f *fakeOutputLister) List(ctx context.Context) ([]output.Info, error) {
+	return f.infos, nil
+}
+
+func (f *fakeOutputLister) Close() error { return nil }
+
+func TestOutputListInfoAndRun(t *testing.T) {
+	t.Run("output list json", func(t *testing.T) {
+		fake := &fakeOutputLister{infos: []output.Info{{
+			Name:        "HDMI-A-1",
+			Backend:     "wayland",
+			Geometry:    output.Geometry{X: 0, Y: 0, W: 1920, H: 1080},
+			ResolutionW: 1920,
+			ResolutionH: 1080,
+			Scale:       2,
+		}}}
+		stdout, stderr, code := captureRunIO(t, []string{"output", "list", "--output", "json"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return &perfuncted.Perfuncted{Output: perfuncted.OutputBundle{Lister: fake}}, nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		var got output.Info
+		if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &got); err != nil {
+			t.Fatalf("json.Unmarshal(stdout) error = %v; stdout=%q", err, stdout)
+		}
+		if got.Name != "HDMI-A-1" || got.Geometry.W != 1920 || got.Scale != 2 {
+			t.Fatalf("decoded output = %+v", got)
+		}
+	})
+
+	t.Run("info json", func(t *testing.T) {
+		stdout, stderr, code := captureRunIO(t, []string{"info", "--output", "json"}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return nil, nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+			t.Fatalf("json.Unmarshal(stdout) error = %v; stdout=%q", err, stdout)
+		}
+		for _, key := range []string{"compositor", "environment", "probes", "capabilities"} {
+			if _, ok := got[key]; !ok {
+				t.Fatalf("missing key %q in info report: %+v", key, got)
+			}
+		}
+	})
+
+	t.Run("run script", func(t *testing.T) {
+		script := filepath.Join(t.TempDir(), "script.pf")
+		if err := os.WriteFile(script, []byte("# comment\ninfo\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		stdout, stderr, code := captureRunIO(t, []string{"run", script}, func(*cliConfig) func() (*perfuncted.Perfuncted, error) {
+			return func() (*perfuncted.Perfuncted, error) {
+				return &perfuncted.Perfuncted{}, nil
+			}
+		})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+			t.Fatalf("json.Unmarshal(stdout) error = %v; stdout=%q", err, stdout)
+		}
+		if _, ok := got["capabilities"]; !ok {
+			t.Fatalf("stdout = %q, want info report", stdout)
 		}
 	})
 }

--- a/docs-cli/pf_find.md
+++ b/docs-cli/pf_find.md
@@ -27,4 +27,5 @@ Pixel scanning and wait utilities
 * [pf find wait-for](pf_find_wait-for.md)	 - Wait until a region's pixel hash equals the provided hash
 * [pf find wait-for-change](pf_find_wait-for-change.md)	 - Wait until a region's pixel hash changes from an initial value
 * [pf find wait-for-no-change](pf_find_wait-for-no-change.md)	 - Wait until a region's pixel hash is stable for N consecutive samples
+* [pf find wait-for-visible-change](pf_find_wait-for-visible-change.md)	 - Wait until a region's visible content changes (useful for animations/loads)
 

--- a/docs-cli/pf_find_wait-for-visible-change.md
+++ b/docs-cli/pf_find_wait-for-visible-change.md
@@ -1,0 +1,33 @@
+## pf find wait-for-visible-change
+
+Wait until a region's visible content changes (useful for animations/loads)
+
+```
+pf find wait-for-visible-change [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for wait-for-visible-change
+      --poll string      poll interval (default "50ms")
+      --rect string      x0,y0,x1,y1 (default "0,0,100,100")
+      --stable int       consecutive identical samples required (default 3)
+      --timeout string   timeout duration (default "5s")
+```
+
+### Options inherited from parent commands
+
+```
+      --max-x int32            input coordinate space width (default 1920)
+      --max-y int32            input coordinate space height (default 1080)
+      --nested                 auto-detect and connect to a nested Wayland session in /tmp
+      --sync                   sync after observable mutating commands when supported
+      --trace-actions          print each API action to stderr as it runs
+      --trace-delay duration   sleep after each traced action
+```
+
+### SEE ALSO
+
+* [pf find](pf_find.md)	 - Pixel scanning and wait utilities
+

--- a/find/find.go
+++ b/find/find.go
@@ -95,7 +95,14 @@ func PixelHash(img image.Image, newHash Hasher) uint32 {
 // implementations provide a fast GrabRegionHash that avoids allocating an
 // image.RGBA; use that when available.
 func GrabHash(ctx context.Context, sc Screenshotter, rect image.Rectangle, newHash Hasher) (uint32, error) {
-	return sc.GrabRegionHash(ctx, rect)
+	if newHash == nil {
+		return sc.GrabRegionHash(ctx, rect)
+	}
+	img, err := sc.Grab(ctx, rect)
+	if err != nil {
+		return 0, err
+	}
+	return PixelHash(img, newHash), nil
 }
 
 // FirstPixel returns the colour of the top-left pixel of rect captured from sc.
@@ -377,6 +384,11 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 	if len(rects) == 0 {
 		return Result{}, fmt.Errorf("find: ScanFor: no regions provided")
 	}
+	for i, r := range rects {
+		if r.Empty() {
+			return Result{}, fmt.Errorf("find: ScanFor: empty region at index %d: %v", i, r)
+		}
+	}
 
 	// Compute union bounding box and total individual area.
 	bbox := rects[0]
@@ -454,6 +466,12 @@ func (a Anchor) Rect(dx, dy, w, h int) image.Rectangle {
 // LocateExact performs an exact byte-for-byte search of reference within the searchArea.
 // It returns the absolute image.Rectangle where it matches.
 func LocateExact(ctx context.Context, sc Screenshotter, searchArea image.Rectangle, reference image.Image) (image.Rectangle, error) {
+	if searchArea.Empty() {
+		return image.Rectangle{}, fmt.Errorf("find: locate search area is empty")
+	}
+	if reference.Bounds().Empty() {
+		return image.Rectangle{}, fmt.Errorf("find: reference image is empty")
+	}
 	src, err := sc.Grab(ctx, searchArea)
 	if err != nil {
 		return image.Rectangle{}, fmt.Errorf("find: locate grab: %w", err)
@@ -551,12 +569,24 @@ func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image
 	if newHash == nil {
 		newHash = DefaultHasher
 	}
+	if radius < 0 {
+		return 0, image.Rectangle{}, fmt.Errorf("find: tolerance radius must be non-negative")
+	}
+	if expectedRect.Empty() {
+		return 0, image.Rectangle{}, fmt.Errorf("find: expected rect is empty")
+	}
+	if reference.Bounds().Empty() {
+		return 0, image.Rectangle{}, fmt.Errorf("find: reference image is empty")
+	}
 	searchArea := image.Rect(
 		expectedRect.Min.X-radius,
 		expectedRect.Min.Y-radius,
 		expectedRect.Max.X+radius,
 		expectedRect.Max.Y+radius,
 	)
+	if searchArea.Empty() {
+		return 0, image.Rectangle{}, fmt.Errorf("find: tolerance search area is empty")
+	}
 
 	// Precompute reference hash and top-left pixel for quick rejection.
 	refHash := PixelHash(reference, newHash)
@@ -686,6 +716,9 @@ func PixelFound(img image.Image, rect image.Rectangle, target color.RGBA, tolera
 // target. Returns the absolute (x, y) of the match. Tolerance is applied per
 // channel: |r-r'| ≤ tol && |g-g'| ≤ tol && |b-b'| ≤ tol.
 func FindColor(ctx context.Context, sc Screenshotter, rect image.Rectangle, target color.RGBA, tolerance int) (image.Point, error) {
+	if tolerance < 0 || tolerance > 255 {
+		return image.Point{}, fmt.Errorf("find: invalid tolerance %d (want 0..255)", tolerance)
+	}
 	img, err := sc.Grab(ctx, rect)
 	if err != nil {
 		return image.Point{}, fmt.Errorf("find: find-color grab: %w", err)

--- a/find/find_bench_test.go
+++ b/find/find_bench_test.go
@@ -1,0 +1,75 @@
+package find
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func BenchmarkPixelHashRGBA(b *testing.B) {
+	img := image.NewRGBA(image.Rect(0, 0, 512, 512))
+	for y := 0; y < 512; y++ {
+		for x := 0; x < 512; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: uint8(x ^ y), A: 255})
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = PixelHash(img, nil)
+	}
+}
+
+func BenchmarkLocateExactRGBA(b *testing.B) {
+	src := image.NewRGBA(image.Rect(0, 0, 256, 256))
+	ref := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	for y := 0; y < 256; y++ {
+		for x := 0; x < 256; x++ {
+			src.SetRGBA(x, y, color.RGBA{R: 50, G: 60, B: 70, A: 255})
+		}
+	}
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			c := color.RGBA{R: uint8(x * 3), G: uint8(y * 5), B: 99, A: 255}
+			src.SetRGBA(180+x, 160+y, c)
+			ref.SetRGBA(x, y, c)
+		}
+	}
+	sc := &fakeScreen{img: src}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := LocateExact(context.Background(), sc, image.Rect(0, 0, 256, 256), ref); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkScanForCompact(b *testing.B) {
+	img := image.NewRGBA(image.Rect(0, 0, 128, 128))
+	for y := 0; y < 128; y++ {
+		for x := 0; x < 128; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: 25, G: 25, B: 25, A: 255})
+		}
+	}
+	img.SetRGBA(16, 16, color.RGBA{R: 200, G: 0, B: 0, A: 255})
+	img.SetRGBA(80, 80, color.RGBA{R: 0, G: 200, B: 0, A: 255})
+
+	sc := &fakeScreen{img: img}
+	rects := []image.Rectangle{image.Rect(0, 0, 32, 32), image.Rect(64, 64, 96, 96)}
+	wants := make([]uint32, len(rects))
+	for i, r := range rects {
+		wants[i] = PixelHash(img.SubImage(r), nil)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ScanFor(context.Background(), sc, rects, wants, 0, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/find/find_test.go
+++ b/find/find_test.go
@@ -160,6 +160,16 @@ func TestLocateExact(t *testing.T) {
 	}
 }
 
+func TestLocateExactEmptyReference(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	sc := &fakeScreen{img: img}
+
+	_, err := LocateExact(context.Background(), sc, image.Rect(0, 0, 20, 20), image.NewRGBA(image.Rect(0, 0, 0, 0)))
+	if err == nil {
+		t.Fatal("expected error for empty reference image")
+	}
+}
+
 // ── uniqueRunes (tested via xkb helper in input package, sanity check here) ──
 
 func TestAnchorRect(t *testing.T) {

--- a/find/find_wait_test.go
+++ b/find/find_wait_test.go
@@ -2,7 +2,7 @@ package find
 
 import (
 	"context"
-	"hash/crc32"
+	"hash/adler32"
 	"image"
 	"image/color"
 	"testing"
@@ -68,7 +68,7 @@ func TestWaitFor_DifferentHash(t *testing.T) {
 
 // TestWaitFor_WithCustomHasher tests WaitFor with a custom hasher.
 func TestWaitFor_WithCustomHasher(t *testing.T) {
-	customHasher := crc32.NewIEEE
+	customHasher := adler32.New
 	sc := &solidScreenshotter{}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -266,6 +266,25 @@ func TestGrabHashSubImage(t *testing.T) {
 	}
 }
 
+func TestGrabHashWithCustomHasher(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: uint8(x * 10), G: uint8(y * 20), B: 7, A: 255})
+		}
+	}
+
+	sc := &fakeScreen{img: img}
+	got, err := GrabHash(context.Background(), sc, image.Rect(0, 0, 4, 4), adler32.New)
+	if err != nil {
+		t.Fatalf("GrabHash returned error: %v", err)
+	}
+	want := PixelHash(img, adler32.New)
+	if got != want {
+		t.Fatalf("GrabHash with custom hasher = %08x, want %08x", got, want)
+	}
+}
+
 // TestScanFor tests ScanFor across multiple regions.
 func TestScanFor(t *testing.T) {
 	// Create an image with patterns at different locations
@@ -351,6 +370,11 @@ func TestScanForEmpty(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty ScanFor input")
 	}
+
+	_, err = ScanFor(context.Background(), &solidScreenshotter{}, []image.Rectangle{image.Rect(0, 0, 0, 1)}, []uint32{1}, 10*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected error for empty ScanFor region")
+	}
 }
 
 // TestWaitWithTolerance tests WaitWithTolerance.
@@ -383,6 +407,16 @@ func TestWaitWithTolerance(t *testing.T) {
 	}
 	if resultRect.Min.X != 4 || resultRect.Min.Y != 4 {
 		t.Fatalf("WaitWithTolerance returned rect %v, want around (4,4)", resultRect)
+	}
+
+	_, _, err = WaitWithTolerance(context.Background(), sc, image.Rect(4, 4, 6, 6), image.NewRGBA(image.Rect(0, 0, 0, 0)), 2, 1*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected error for empty reference image")
+	}
+
+	_, _, err = WaitWithTolerance(context.Background(), sc, image.Rect(4, 4, 6, 6), ref, -1, 1*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected error for negative tolerance radius")
 	}
 }
 
@@ -441,6 +475,10 @@ func TestFindColor(t *testing.T) {
 	}
 	if pt2.X != 3 || pt2.Y != 3 {
 		t.Fatalf("FindColor with tolerance returned (%d,%d), want (3,3)", pt2.X, pt2.Y)
+	}
+
+	if _, err := FindColor(context.Background(), sc, image.Rect(0, 0, 10, 10), target, -1); err == nil {
+		t.Fatal("expected error for negative tolerance")
 	}
 }
 


### PR DESCRIPTION
## Summary\n- fix custom-hasher handling in find hashing and reject invalid/empty search inputs\n- register the missing `find wait-for-visible-change` command and tighten CLI sync/visibility behavior\n- add CLI coverage for unique commands plus benchmarks for hot find paths\n\n## Validation\n- go test ./cmd/pf ./find ./...\n- CGO_ENABLED=0 go run ./scripts/verify_cli_api.go\n