### PR TITLE
feat: DRY tests, add benchmarks, fix 3 keyboard input bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ sway.log
 primary.txt
 clipboard.txt
 /ffprof/
-coverage.out
+coverage*.out
 *.cover

--- a/find/find_bench_test.go
+++ b/find/find_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"image/color"
 	"testing"
+	"time"
 )
 
 func BenchmarkPixelHashRGBA(b *testing.B) {
@@ -69,6 +70,65 @@ func BenchmarkScanForCompact(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := ScanFor(context.Background(), sc, rects, wants, 0, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWaitForFn_ImmediatelyTrue measures the latency floor when the
+// predicate is satisfied on the very first poll.
+func BenchmarkWaitForFn_ImmediatelyTrue(b *testing.B) {
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	sc := &fakeScreen{img: img}
+	rect := image.Rect(0, 0, 64, 64)
+	pred := func(_ context.Context, _ image.Image) bool { return true }
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := WaitForFn(context.Background(), sc, rect, pred, 10*time.Millisecond); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWaitForFn_FivePollIterations measures cost when predicate becomes
+// true after 5 grabs (exercises the poll loop).
+func BenchmarkWaitForFn_FivePollIterations(b *testing.B) {
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	sc := &fakeScreen{img: img}
+	rect := image.Rect(0, 0, 64, 64)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		pred := func(_ context.Context, _ image.Image) bool {
+			count++
+			return count >= 5
+		}
+		if _, err := WaitForFn(context.Background(), sc, rect, pred, 1*time.Microsecond); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWaitFor_ImmediatelyTrue measures WaitFor when the hash matches immediately.
+func BenchmarkWaitFor_ImmediatelyTrue(b *testing.B) {
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for y := 0; y < 64; y++ {
+		for x := 0; x < 64; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 42, A: 255})
+		}
+	}
+	sc := &fakeScreen{img: img}
+	rect := image.Rect(0, 0, 64, 64)
+	want := PixelHash(img, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := WaitFor(context.Background(), sc, rect, want, 1*time.Millisecond, nil); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/input/input_bench_test.go
+++ b/input/input_bench_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+// +build linux
+
+package input
+
+import (
+	"testing"
+)
+
+func BenchmarkParseKeySend_Literal(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseKeySend("hello world this is a test string")
+	}
+}
+
+func BenchmarkParseKeySend_SingleKey(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseKeySend("{enter}")
+	}
+}
+
+func BenchmarkParseKeySend_Combo(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseKeySend("{ctrl+shift+t}")
+	}
+}
+
+func BenchmarkParseKeySend_Mixed(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseKeySend("Hello{enter}{ctrl+s}World{escape}")
+	}
+}
+
+func BenchmarkParseKeySend_HoldRelease(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseKeySend("{ctrl down}v{ctrl up}")
+	}
+}

--- a/input/keysend_test.go
+++ b/input/keysend_test.go
@@ -4,140 +4,83 @@ import (
 	"testing"
 )
 
-func TestParseKeySend_LiteralText(t *testing.T) {
-	sends, err := ParseKeySend("hello world")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].text != "hello world" {
-		t.Errorf("text = %q, want %q", sends[0].text, "hello world")
-	}
+type keySendCase struct {
+	name  string
+	input string
+	want  keySend
 }
 
-func TestParseKeySend_NamedKey(t *testing.T) {
-	sends, err := ParseKeySend("{enter}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
+func TestParseKeySend_Table(t *testing.T) {
+	cases := []keySendCase{
+		{
+			name:  "LiteralText",
+			input: "hello world",
+			want:  keySend{text: "hello world"},
+		},
+		{
+			name:  "NamedKey",
+			input: "{enter}",
+			want:  keySend{key: "enter"},
+		},
+		{
+			name:  "KeyDown",
+			input: "{ctrl down}",
+			want:  keySend{key: "ctrl", down: true},
+		},
+		{
+			name:  "KeyUp",
+			input: "{shift up}",
+			want:  keySend{key: "shift"},
+		},
+		{
+			name:  "BraceCombo",
+			input: "{ctrl+s}",
+			want:  keySend{key: "s", modifiers: modifiers{ctrl: true}},
+		},
+		{
+			name:  "BraceComboMultipleModifiers",
+			input: "{ctrl+shift+left}",
+			want:  keySend{key: "left", modifiers: modifiers{ctrl: true, shift: true}},
+		},
+		{
+			name:  "BraceComboSuper",
+			input: "{super+tab}",
+			want:  keySend{key: "tab", modifiers: modifiers{super: true}},
+		},
+		{
+			name:  "BraceComboMetaAlias",
+			input: "{meta+tab}",
+			want:  keySend{key: "tab", modifiers: modifiers{super: true}},
+		},
+		{
+			name:  "BraceComboAllModifiers",
+			input: "{ctrl+alt+shift+super+a}",
+			want:  keySend{key: "a", modifiers: modifiers{ctrl: true, alt: true, shift: true, super: true}},
+		},
+		{
+			name:  "CaseInsensitive",
+			input: "{ENTER}",
+			want:  keySend{key: "enter"},
+		},
+		{
+			name:  "BraceComboCaseInsensitive",
+			input: "{CTRL+SHIFT+T}",
+			want:  keySend{key: "t", modifiers: modifiers{ctrl: true, shift: true}},
+		},
 	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "enter" {
-		t.Errorf("key = %q, want %q", sends[0].key, "enter")
-	}
-	if sends[0].down {
-		t.Error("expected down=false for plain key tap")
-	}
-}
-
-func TestParseKeySend_KeyDown(t *testing.T) {
-	sends, err := ParseKeySend("{ctrl down}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "ctrl" {
-		t.Errorf("key = %q, want %q", sends[0].key, "ctrl")
-	}
-	if !sends[0].down {
-		t.Error("expected down=true")
-	}
-}
-
-func TestParseKeySend_KeyUp(t *testing.T) {
-	sends, err := ParseKeySend("{shift up}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "shift" {
-		t.Errorf("key = %q, want %q", sends[0].key, "shift")
-	}
-	if sends[0].down {
-		t.Error("expected down=false for key up")
-	}
-}
-
-func TestParseKeySend_BraceCombo(t *testing.T) {
-	sends, err := ParseKeySend("{ctrl+s}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "s" {
-		t.Errorf("key = %q, want %q", sends[0].key, "s")
-	}
-	if !sends[0].modifiers.ctrl {
-		t.Error("expected ctrl modifier")
-	}
-}
-
-func TestParseKeySend_BraceComboMultipleModifiers(t *testing.T) {
-	sends, err := ParseKeySend("{ctrl+shift+left}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "left" {
-		t.Errorf("key = %q, want %q", sends[0].key, "left")
-	}
-	m := sends[0].modifiers
-	if !m.ctrl || !m.shift || m.alt || m.super {
-		t.Errorf("expected ctrl+shift only, got %+v", m)
-	}
-}
-
-func TestParseKeySend_BraceComboSuper(t *testing.T) {
-	sends, err := ParseKeySend("{super+tab}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	if sends[0].key != "tab" {
-		t.Errorf("key = %q, want %q", sends[0].key, "tab")
-	}
-	if !sends[0].modifiers.super {
-		t.Error("expected super modifier")
-	}
-}
-
-func TestParseKeySend_BraceComboMetaAlias(t *testing.T) {
-	sends, err := ParseKeySend("{meta+tab}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if !sends[0].modifiers.super {
-		t.Error("expected super modifier for meta alias")
-	}
-}
-
-func TestParseKeySend_BraceComboAllModifiers(t *testing.T) {
-	sends, err := ParseKeySend("{ctrl+alt+shift+super+a}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if len(sends) != 1 {
-		t.Fatalf("expected 1 send, got %d", len(sends))
-	}
-	m := sends[0].modifiers
-	if !m.ctrl || !m.alt || !m.shift || !m.super {
-		t.Errorf("expected all modifiers, got %+v", m)
-	}
-	if sends[0].key != "a" {
-		t.Errorf("key = %q, want %q", sends[0].key, "a")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sends, err := ParseKeySend(tc.input)
+			if err != nil {
+				t.Fatalf("ParseKeySend(%q) error = %v", tc.input, err)
+			}
+			if len(sends) != 1 {
+				t.Fatalf("ParseKeySend(%q) returned %d sends, want 1", tc.input, len(sends))
+			}
+			if sends[0] != tc.want {
+				t.Errorf("ParseKeySend(%q) = %+v, want %+v", tc.input, sends[0], tc.want)
+			}
+		})
 	}
 }
 
@@ -180,47 +123,22 @@ func TestParseKeySend_HoldAndRelease(t *testing.T) {
 	}
 }
 
-func TestParseKeySend_UnclosedBrace(t *testing.T) {
-	_, err := ParseKeySend("{enter")
-	if err == nil {
-		t.Fatal("expected error for unclosed brace")
+func TestParseKeySend_Errors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"UnclosedBrace", "{enter"},
+		{"EmptyBraces", "{}"},
+		{"BraceComboEndsWithModifier", "{ctrl+shift}"},
 	}
-}
-
-func TestParseKeySend_EmptyBraces(t *testing.T) {
-	_, err := ParseKeySend("{}")
-	if err == nil {
-		t.Fatal("expected error for empty braces")
-	}
-}
-
-func TestParseKeySend_BraceComboEndsWithModifier(t *testing.T) {
-	_, err := ParseKeySend("{ctrl+shift}")
-	if err == nil {
-		t.Fatal("expected error for combo ending with modifier")
-	}
-}
-
-func TestParseKeySend_CaseInsensitive(t *testing.T) {
-	sends, err := ParseKeySend("{ENTER}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if sends[0].key != "enter" {
-		t.Errorf("key = %q, want %q", sends[0].key, "enter")
-	}
-}
-
-func TestParseKeySend_BraceComboCaseInsensitive(t *testing.T) {
-	sends, err := ParseKeySend("{CTRL+SHIFT+T}")
-	if err != nil {
-		t.Fatalf("ParseKeySend: %v", err)
-	}
-	if sends[0].key != "t" {
-		t.Errorf("key = %q, want %q", sends[0].key, "t")
-	}
-	if !sends[0].modifiers.ctrl || !sends[0].modifiers.shift {
-		t.Errorf("expected ctrl+shift, got %+v", sends[0].modifiers)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseKeySend(tc.input)
+			if err == nil {
+				t.Fatalf("ParseKeySend(%q) expected error, got nil", tc.input)
+			}
+		})
 	}
 }
 

--- a/input/misc_test.go
+++ b/input/misc_test.go
@@ -104,36 +104,34 @@ func TestParseKeySequence_KeysOnly(t *testing.T) {
 
 // ── parseCombo — modifier aliases ─────────────────────────────────────────────
 
-func TestParseCombo_WinModifier(t *testing.T) {
-	ks, err := ParseKeySend("{win+d}")
-	if err != nil {
-		t.Fatalf("ParseKeySend({win+d}) error = %v", err)
+func TestParseCombo_ModifierAliases(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantKey   string
+		wantSuper bool
+		wantCtrl  bool
+	}{
+		{name: "WinModifier", input: "{win+d}", wantKey: "d", wantSuper: true},
+		{name: "LogoModifier", input: "{logo+l}", wantKey: "l", wantSuper: true},
+		{name: "ControlAlias", input: "{control+c}", wantKey: "c", wantCtrl: true},
 	}
-	if !ks[0].modifiers.super {
-		t.Error("expected super modifier for win alias")
-	}
-	if ks[0].key != "d" {
-		t.Errorf("key = %q, want d", ks[0].key)
-	}
-}
-
-func TestParseCombo_LogoModifier(t *testing.T) {
-	ks, err := ParseKeySend("{logo+l}")
-	if err != nil {
-		t.Fatalf("ParseKeySend({logo+l}) error = %v", err)
-	}
-	if !ks[0].modifiers.super {
-		t.Error("expected super modifier for logo alias")
-	}
-}
-
-func TestParseCombo_ControlAlias(t *testing.T) {
-	ks, err := ParseKeySend("{control+c}")
-	if err != nil {
-		t.Fatalf("ParseKeySend({control+c}) error = %v", err)
-	}
-	if !ks[0].modifiers.ctrl {
-		t.Error("expected ctrl modifier for control alias")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ks, err := ParseKeySend(tc.input)
+			if err != nil {
+				t.Fatalf("ParseKeySend(%q) error = %v", tc.input, err)
+			}
+			if ks[0].key != tc.wantKey {
+				t.Errorf("key = %q, want %q", ks[0].key, tc.wantKey)
+			}
+			if ks[0].modifiers.super != tc.wantSuper {
+				t.Errorf("super = %v, want %v", ks[0].modifiers.super, tc.wantSuper)
+			}
+			if ks[0].modifiers.ctrl != tc.wantCtrl {
+				t.Errorf("ctrl = %v, want %v", ks[0].modifiers.ctrl, tc.wantCtrl)
+			}
+		})
 	}
 }
 

--- a/input/uinput.go
+++ b/input/uinput.go
@@ -174,54 +174,67 @@ func (b *UinputBackend) TypeContext(ctx context.Context, s string) error {
 		if err != nil {
 			return err
 		}
-		if a.modifiers.shift {
-			if err := b.kb.KeyDown(uinput.KeyLeftshift); err != nil {
-				return err
-			}
+		if err := b.typeKeyWithMods(code, a.down, a.modifiers); err != nil {
+			return err
 		}
-		if a.modifiers.ctrl {
-			if err := b.kb.KeyDown(uinput.KeyLeftctrl); err != nil {
-				return err
-			}
+	}
+	return nil
+}
+
+// typeKeyWithMods presses modifier keys, sends the key action, then releases
+// modifiers in reverse order. If any step fails, already-pressed modifiers
+// are released (best-effort) before the error is returned.
+func (b *UinputBackend) typeKeyWithMods(code int, down bool, mods modifiers) error {
+	// Build ordered list of modifier keycodes.
+	var modKeys []int
+	if mods.shift {
+		modKeys = append(modKeys, uinput.KeyLeftshift)
+	}
+	if mods.ctrl {
+		modKeys = append(modKeys, uinput.KeyLeftctrl)
+	}
+	if mods.alt {
+		modKeys = append(modKeys, uinput.KeyLeftalt)
+	}
+	if mods.super {
+		modKeys = append(modKeys, uinput.KeyLeftmeta)
+	}
+
+	// Press modifiers; release any already-pressed ones on failure.
+	pressed := 0
+	releaseHeld := func() {
+		for i := pressed - 1; i >= 0; i-- {
+			_ = b.kb.KeyUp(modKeys[i])
 		}
-		if a.modifiers.alt {
-			if err := b.kb.KeyDown(uinput.KeyLeftalt); err != nil {
-				return err
-			}
+	}
+	for _, mk := range modKeys {
+		if err := b.kb.KeyDown(mk); err != nil {
+			releaseHeld()
+			return err
 		}
-		if a.modifiers.super {
-			if err := b.kb.KeyDown(uinput.KeyLeftmeta); err != nil {
-				return err
-			}
+		pressed++
+	}
+
+	// Send the key.
+	if down {
+		if err := b.kb.KeyDown(code); err != nil {
+			releaseHeld()
+			return err
 		}
-		if a.down {
-			if err := b.kb.KeyDown(code); err != nil {
-				return err
-			}
-		} else {
-			if err := b.kb.KeyPress(code); err != nil {
-				return err
-			}
+	} else {
+		if err := b.kb.KeyPress(code); err != nil {
+			releaseHeld()
+			return err
 		}
-		if a.modifiers.super {
-			if err := b.kb.KeyUp(uinput.KeyLeftmeta); err != nil {
-				return err
+	}
+
+	// Release modifiers in reverse order.
+	for i := len(modKeys) - 1; i >= 0; i-- {
+		if err := b.kb.KeyUp(modKeys[i]); err != nil {
+			for j := i - 1; j >= 0; j-- {
+				_ = b.kb.KeyUp(modKeys[j])
 			}
-		}
-		if a.modifiers.alt {
-			if err := b.kb.KeyUp(uinput.KeyLeftalt); err != nil {
-				return err
-			}
-		}
-		if a.modifiers.ctrl {
-			if err := b.kb.KeyUp(uinput.KeyLeftctrl); err != nil {
-				return err
-			}
-		}
-		if a.modifiers.shift {
-			if err := b.kb.KeyUp(uinput.KeyLeftshift); err != nil {
-				return err
-			}
+			return err
 		}
 	}
 	return nil

--- a/input/uinput_test.go
+++ b/input/uinput_test.go
@@ -308,3 +308,48 @@ func TestKernelRuneExtraction(t *testing.T) {
 		}
 	}
 }
+
+// failingKeyboard wraps recordingKeyboard and fails on KeyPress calls.
+type failingKeyboard struct {
+	recordingKeyboard
+	failPress bool
+}
+
+func (f *failingKeyboard) KeyPress(key int) error {
+	if f.failPress {
+		return fmt.Errorf("injected KeyPress failure for key %d", key)
+	}
+	return f.recordingKeyboard.KeyPress(key)
+}
+
+// TestTypeKeyWithMods_ModifierReleasedOnKeyPressFailure verifies that modifier
+// keys are released (best-effort) when the key action itself fails. Before the
+// fix, the pressed modifier was leaked (never released).
+func TestTypeKeyWithMods_ModifierReleasedOnKeyPressFailure(t *testing.T) {
+	kb := &failingKeyboard{failPress: true}
+	b := &UinputBackend{kb: kb, charToRune: qwertyRuneMap()}
+
+	// {shift+a}: presses shift (succeeds), then KeyPress('a') fails.
+	// The fix should release shift even though KeyPress failed.
+	err := b.TypeContext(context.Background(), "{shift+a}")
+	if err == nil {
+		t.Fatal("expected error from injected failure")
+	}
+
+	// Verify shift KeyDown was called.
+	var downCount, upCount int
+	for _, ev := range kb.events {
+		if ev == fmt.Sprintf("down:%d", uinput.KeyLeftshift) {
+			downCount++
+		}
+		if ev == fmt.Sprintf("up:%d", uinput.KeyLeftshift) {
+			upCount++
+		}
+	}
+	if downCount == 0 {
+		t.Error("shift KeyDown was never called")
+	}
+	if upCount == 0 {
+		t.Errorf("shift KeyUp was never called after failure; events: %v", kb.events)
+	}
+}

--- a/input/wl_keyboard.go
+++ b/input/wl_keyboard.go
@@ -125,6 +125,39 @@ func (k *wlKeyboard) uploadKeymapAndRestoreMods(keymap string) error {
 	return nil
 }
 
+// applyTempMods applies modBitmask to k.mods and sends the modifier state.
+// If sendModifiers fails, local state is rolled back and error is returned.
+func (k *wlKeyboard) applyTempMods(modBitmask uint32) error {
+	if modBitmask == 0 {
+		return nil
+	}
+	k.mods |= modBitmask
+	if err := k.sendModifiers(); err != nil {
+		k.mods &^= modBitmask
+		return err
+	}
+	return nil
+}
+
+// clearTempMods removes modBitmask from k.mods and sends the update.
+func (k *wlKeyboard) clearTempMods(modBitmask uint32) error {
+	if modBitmask == 0 {
+		return nil
+	}
+	k.mods &^= modBitmask
+	return k.sendModifiers()
+}
+
+// clearTempModsBestEffort is like clearTempMods but ignores errors.
+// Use on error paths where cleanup must be attempted before returning.
+func (k *wlKeyboard) clearTempModsBestEffort(modBitmask uint32) {
+	if modBitmask == 0 {
+		return
+	}
+	k.mods &^= modBitmask
+	_ = k.sendModifiers()
+}
+
 // sendkeys processes a sequence of parsed keySend actions with a single
 // keymap upload. This avoids the modifier-state-reset problem that occurs
 // when pressing multiple keys via separate pressKey calls (each uploads a
@@ -265,11 +298,8 @@ func (k *wlKeyboard) sendkeysContext(ctx context.Context, actions []keySend) err
 			modBitmask |= modMod4
 		}
 
-		if modBitmask != 0 {
-			k.mods |= modBitmask
-			if err := k.sendModifiers(); err != nil {
-				return err
-			}
+		if err := k.applyTempMods(modBitmask); err != nil {
+			return err
 		}
 
 		if kc, _, ok := namedKey(ka.key); ok {
@@ -281,35 +311,43 @@ func (k *wlKeyboard) sendkeysContext(ctx context.Context, actions []keySend) err
 					k.mods &^= bit
 				}
 				if err := k.sendKey(kc, 1); err != nil {
+					k.clearTempModsBestEffort(modBitmask)
 					return err
 				}
 				if !ka.down {
 					if err := k.sendKey(kc, 0); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 				}
 				if err := k.sendModifiers(); err != nil {
+					k.clearTempModsBestEffort(modBitmask)
 					return err
 				}
 			} else {
 				// Named non-modifier key.
 				slot := namedSlots[ka.key]
 				if ka.down {
-					k.held[ka.key] = slot
 					if err := k.sendKey(slot, 1); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
+					k.held[ka.key] = slot
 				} else {
 					if err := k.sendKey(slot, 1); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 					if err := sleepContext(ctx, 10*time.Millisecond); err != nil {
 						if upErr := k.sendKey(slot, 0); upErr != nil {
+							k.clearTempModsBestEffort(modBitmask)
 							return upErr
 						}
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 					if err := k.sendKey(slot, 0); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 					delete(k.held, ka.key)
@@ -320,15 +358,18 @@ func (k *wlKeyboard) sendkeysContext(ctx context.Context, actions []keySend) err
 			for _, r := range ka.key {
 				slot := runeSlots[r]
 				if ka.down {
-					k.held[ka.key] = slot
 					if err := k.sendKey(slot, 1); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
+					k.held[ka.key] = slot
 				} else {
 					if err := k.tapContext(ctx, slot); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 					if err := sleepContext(ctx, 10*time.Millisecond); err != nil {
+						k.clearTempModsBestEffort(modBitmask)
 						return err
 					}
 				}
@@ -336,11 +377,8 @@ func (k *wlKeyboard) sendkeysContext(ctx context.Context, actions []keySend) err
 		}
 
 		// Release temporary modifiers.
-		if modBitmask != 0 {
-			k.mods &^= modBitmask
-			if err := k.sendModifiers(); err != nil {
-				return err
-			}
+		if err := k.clearTempMods(modBitmask); err != nil {
+			return err
 		}
 	}
 

--- a/input/wlkeyboard_keyevents_test.go
+++ b/input/wlkeyboard_keyevents_test.go
@@ -5,6 +5,8 @@ package input
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -36,6 +38,29 @@ func newTestKeyboard() (*wlKeyboard, *recordingCtx) {
 	rp.SetID(42)
 	k.kbd = rp
 	f := &recordingCtx{}
+	k.ctx = f
+	return k, f
+}
+
+// failingCtx is a recordingCtx that returns an error after successWrites writes.
+type failingCtx struct {
+	recordingCtx
+	successWrites int // number of writes to allow before failing
+}
+
+func (f *failingCtx) WriteMsg(data, oob []byte) error {
+	if f.writes >= f.successWrites {
+		return errors.New("injected write failure")
+	}
+	return f.recordingCtx.WriteMsg(data, oob)
+}
+
+func newFailingKeyboard(successWrites int) (*wlKeyboard, *failingCtx) {
+	k := &wlKeyboard{held: make(map[string]uint32)}
+	rp := &wl.RawProxy{}
+	rp.SetID(42)
+	k.kbd = rp
+	f := &failingCtx{successWrites: successWrites}
 	k.ctx = f
 	return k, f
 }
@@ -556,4 +581,49 @@ const maxDynSlots = testMaxDynSlots
 // uniqueRunes is exported for tests in wl_keyboard_test.go.
 func uniqueRunes(s string) []rune {
 	return testUniqueRunes(s)
+}
+
+// TestSendkeysContext_HeldNotSetOnSendKeyFailure verifies that k.held is NOT
+// populated when the sendKey call for a key-down action fails. Before the fix,
+// k.held was set before sendKey, leaving a phantom held key on failure.
+func TestSendkeysContext_HeldNotSetOnSendKeyFailure(t *testing.T) {
+	// sendkeysContext does 1 write for keymap upload; the next write is sendKey.
+	// Allow 1 write (keymap) then fail.
+	k, _ := newFailingKeyboard(1)
+
+	actions, err := ParseKeySend("{enter down}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// Should fail because sendKey (write 1) fails.
+	if err := k.sendkeysContext(context.Background(), actions); err == nil {
+		t.Fatal("expected error from injected write failure")
+	}
+	if len(k.held) != 0 {
+		t.Errorf("k.held = %v after sendKey failure, want empty map", k.held)
+	}
+}
+
+// TestSendkeysContext_ModifierClearedOnSendKeyFailure verifies that k.mods is
+// restored to its original value when a sendKey fails after temporary modifiers
+// were applied. Before the fix, k.mods retained the temporary modifier bits.
+func TestSendkeysContext_ModifierClearedOnSendKeyFailure(t *testing.T) {
+	// For {ctrl+s}:
+	//   write 0: keymap upload
+	//   write 1: sendModifiers (apply ctrl)
+	//   write 2: sendKey(slot, 1) — we want this to fail
+	// Allow 2 writes (keymap + sendModifiers) then fail.
+	k, _ := newFailingKeyboard(2)
+
+	actions, err := ParseKeySend("{ctrl+s}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	initialMods := k.mods
+	if err := k.sendkeysContext(context.Background(), actions); err == nil {
+		t.Fatal("expected error from injected write failure")
+	}
+	if k.mods != initialMods {
+		t.Errorf("k.mods = %08b after failure, want %08b (should be restored to initial)", k.mods, initialMods)
+	}
 }

--- a/window/find_bench_test.go
+++ b/window/find_bench_test.go
@@ -1,0 +1,66 @@
+package window
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkMatchMatches_TitleContains(b *testing.B) {
+	info := Info{ID: 1, Title: "Firefox Web Browser", AppID: "org.mozilla.firefox", Active: true}
+	m := Match{TitleContains: "firefox"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Matches(info)
+	}
+}
+
+func BenchmarkMatchMatches_TitleExact(b *testing.B) {
+	info := Info{ID: 1, Title: "Firefox Web Browser", AppID: "org.mozilla.firefox"}
+	m := Match{TitleExact: "firefox web browser"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Matches(info)
+	}
+}
+
+func BenchmarkMatchMatches_MultiField(b *testing.B) {
+	active := true
+	info := Info{ID: 7, Title: "Editor", AppID: "org.example.editor", PID: 42, Active: true}
+	m := Match{TitleContains: "editor", AppID: "org.example.editor", Active: &active}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Matches(info)
+	}
+}
+
+func BenchmarkFindByTitle(b *testing.B) {
+	wins := make([]Info, 20)
+	for i := range wins {
+		wins[i] = Info{ID: uint64(i + 1), Title: "Window " + string(rune('A'+i)), AppID: "org.example.app"}
+	}
+	wins[19].Title = "Target Window"
+	m := &fakeManager{wins: wins}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = FindByTitle(context.Background(), m, "target")
+	}
+}
+
+func BenchmarkFind_MatchByAppID(b *testing.B) {
+	wins := make([]Info, 20)
+	for i := range wins {
+		wins[i] = Info{ID: uint64(i + 1), Title: "Window", AppID: "org.other.app"}
+	}
+	wins[19].AppID = "org.target.app"
+	m := &fakeManager{wins: wins}
+	match := Match{AppID: "org.target.app"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Find(context.Background(), m, match)
+	}
+}


### PR DESCRIPTION
## Summary

Three-goal improvement pass on the `input/`, `find/`, and `window/` packages.

### Goal 1 – DRY test refactoring

- **`input/keysend_test.go`**: Replaced 11 individual single-token success tests and 3 individual error tests with table-driven `TestParseKeySend_Table` and `TestParseKeySend_Errors`.
- **`input/misc_test.go`**: Replaced `TestParseCombo_Win`, `TestParseCombo_Logo`, `TestParseCombo_ControlAlias` with a single `TestParseCombo_ModifierAliases` table-driven test.

### Goal 2 – Benchmarks

- **`find/find_bench_test.go`**: Added `BenchmarkWaitForFn_ImmediatelyTrue`, `BenchmarkWaitForFn_FivePollIterations`, `BenchmarkWaitFor_ImmediatelyTrue`.
- **`input/input_bench_test.go`** (new): 5 `ParseKeySend` benchmarks covering Literal, SingleKey, Combo, Mixed, and HoldRelease sequences.
- **`window/find_bench_test.go`** (new): 5 benchmarks for `Match.Matches` (TitleContains, TitleExact, MultiField), `FindByTitle`, and `Find`.

### Goal 3 – Bug fixes in keyboard input handling

**Bug 1 – `k.held` set before `sendKey` succeeds** (`wl_keyboard.go`)
In `sendkeysContext`, for a `ka.down=true` key action, `k.held[ka.key] = slot` was set *before* calling `sendKey`. If `sendKey` failed, the key appeared held but was never pressed. Fixed to only set `held` after success (consistent with `pressKey`).

**Bug 2 – Modifier bits stuck in `k.mods` on error** (`wl_keyboard.go`)
When a keySend action had combo modifiers (e.g. `{ctrl+s}`), `sendkeysContext` applied `k.mods |= modBitmask` but never cleared those bits on error paths. On any failure, the modifier stayed set, causing the next `uploadKeymapAndRestoreMods` call to unexpectedly re-apply those modifiers. Added `applyTempMods`, `clearTempMods`, and `clearTempModsBestEffort` helpers; all error paths now call `clearTempModsBestEffort`.

**Bug 3 – Modifier keys not released on key press failure** (`uinput.go`)
In `UinputBackend.TypeContext`, if the actual key press failed after modifiers were already pressed, those modifiers were never released. Added `typeKeyWithMods` helper with a `pressed` counter and `releaseHeld` defer/cleanup closure.

**Regression tests** for all 3 bugs added in `wlkeyboard_keyevents_test.go` and `uinput_test.go`.

### Misc
- Updated `.gitignore` to cover `coverage*.out` (previously only `coverage.out`).