### PR TITLE
fix(screen): reject truncated x11 pixel buffers

### DIFF
--- a/screen/pixels.go
+++ b/screen/pixels.go
@@ -11,24 +11,22 @@ import (
 // This function is used by multiple backends (wlrscreencopy, extcapture, x11)
 // that all receive BGRA frames from the compositor or X server.
 func decodeBGRA(data []byte, w, h, stride int) *image.RGBA {
-	if len(data) == 0 || w <= 0 || h <= 0 {
+	if len(data) == 0 || w <= 0 || h <= 0 || stride <= 0 {
 		return image.NewRGBA(image.Rect(0, 0, 0, 0))
 	}
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
 	rowBytes := w * 4
 	for row := 0; row < h; row++ {
-		srcRow := data[row*stride : row*stride+rowBytes]
-		dstOff := row * img.Stride
-		dst := img.Pix[dstOff : dstOff+rowBytes]
-		// iterate by bytes to reduce multiplications inside loop
-		for s := 0; s < rowBytes; s += 4 {
-			_ = srcRow[s+3]        // eliminate bounds check
-			_ = dst[s+3]           // eliminate bounds check
-			dst[s+0] = srcRow[s+2] // R ← B
-			dst[s+1] = srcRow[s+1] // G ← G
-			dst[s+2] = srcRow[s+0] // B ← R
-			dst[s+3] = 0xff        // A
+		srcStart := row * stride
+		if srcStart >= len(data) {
+			break
 		}
+		srcEnd := srcStart + rowBytes
+		if srcEnd > len(data) {
+			srcEnd = len(data)
+		}
+		dstOff := row * img.Stride
+		copyBGRA(img.Pix[dstOff:dstOff+rowBytes], data[srcStart:srcEnd])
 	}
 	return img
 }
@@ -37,6 +35,9 @@ func decodeBGRA(data []byte, w, h, stride int) *image.RGBA {
 // image. This avoids allocating and decoding the entire screen when only a
 // small region is needed.
 func decodeBGRARect(data []byte, w, h, stride int, rect image.Rectangle) *image.RGBA {
+	if len(data) == 0 || w <= 0 || h <= 0 || stride <= 0 {
+		return image.NewRGBA(image.Rect(0, 0, 0, 0))
+	}
 	r := rect.Intersect(image.Rect(0, 0, w, h))
 	if r.Empty() {
 		return image.NewRGBA(image.Rect(0, 0, 0, 0))
@@ -44,19 +45,32 @@ func decodeBGRARect(data []byte, w, h, stride int, rect image.Rectangle) *image.
 	out := image.NewRGBA(r)
 	rowBytes := r.Dx() * 4
 	for y := 0; y < r.Dy(); y++ {
-		srcRow := data[(r.Min.Y+y)*stride+r.Min.X*4 : (r.Min.Y+y)*stride+r.Min.X*4+rowBytes]
-		dstOff := y * out.Stride
-		dst := out.Pix[dstOff : dstOff+rowBytes]
-		for s := 0; s < rowBytes; s += 4 {
-			_ = srcRow[s+3]        // eliminate bounds check
-			_ = dst[s+3]           // eliminate bounds check
-			dst[s+0] = srcRow[s+2] // R ← B
-			dst[s+1] = srcRow[s+1] // G ← G
-			dst[s+2] = srcRow[s+0] // B ← R
-			dst[s+3] = 0xff        // A
+		srcStart := (r.Min.Y+y)*stride + r.Min.X*4
+		if srcStart >= len(data) {
+			break
 		}
+		srcEnd := srcStart + rowBytes
+		if srcEnd > len(data) {
+			srcEnd = len(data)
+		}
+		dstOff := y * out.Stride
+		copyBGRA(out.Pix[dstOff:dstOff+rowBytes], data[srcStart:srcEnd])
 	}
 	return out
+}
+
+func copyBGRA(dst, src []byte) {
+	n := len(src)
+	if len(dst) < n {
+		n = len(dst)
+	}
+	n -= n % 4
+	for i := 0; i < n; i += 4 {
+		dst[i+0] = src[i+2] // R ← B
+		dst[i+1] = src[i+1] // G ← G
+		dst[i+2] = src[i+0] // B ← R
+		dst[i+3] = 0xff     // A
+	}
 }
 
 // cropRGBA extracts the sub-rectangle rect from a full-screen RGBA image,

--- a/screen/pixels_test.go
+++ b/screen/pixels_test.go
@@ -158,3 +158,48 @@ func TestDecodeBGRARectWithStridePadding(t *testing.T) {
 		t.Errorf("row 1: got RGB(%02x,%02x,%02x) want (16,15,14)", c1.R, c1.G, c1.B)
 	}
 }
+
+func TestDecodeBGRAShortDataDoesNotPanic(t *testing.T) {
+	// 2x2 image, but only the first row is present.
+	data := []byte{
+		0x01, 0x02, 0x03, 0xFF,
+		0x04, 0x05, 0x06, 0xFF,
+	}
+
+	img := decodeBGRA(data, 2, 2, 8)
+	if got := img.Bounds(); got != image.Rect(0, 0, 2, 2) {
+		t.Fatalf("bounds = %v, want 2x2", got)
+	}
+	if c := img.RGBAAt(0, 0); c.R != 0x03 || c.G != 0x02 || c.B != 0x01 || c.A != 0xFF {
+		t.Fatalf("top-left pixel = %+v, want RGBA(03,02,01,FF)", c)
+	}
+	if c := img.RGBAAt(1, 0); c.R != 0x06 || c.G != 0x05 || c.B != 0x04 || c.A != 0xFF {
+		t.Fatalf("top-right pixel = %+v, want RGBA(06,05,04,FF)", c)
+	}
+	if c := img.RGBAAt(0, 1); c != (color.RGBA{}) {
+		t.Fatalf("bottom-left pixel = %+v, want zero value", c)
+	}
+}
+
+func TestDecodeBGRARectShortDataDoesNotPanic(t *testing.T) {
+	// 2x2 image, but only the first row is present.
+	data := []byte{
+		0x01, 0x02, 0x03, 0xFF,
+		0x04, 0x05, 0x06, 0xFF,
+	}
+
+	rect := image.Rect(0, 0, 2, 2)
+	img := decodeBGRARect(data, 2, 2, 8, rect)
+	if got := img.Bounds(); got != rect {
+		t.Fatalf("bounds = %v, want %v", got, rect)
+	}
+	if c := img.RGBAAt(0, 0); c.R != 0x03 || c.G != 0x02 || c.B != 0x01 || c.A != 0xFF {
+		t.Fatalf("top-left pixel = %+v, want RGBA(03,02,01,FF)", c)
+	}
+	if c := img.RGBAAt(1, 0); c.R != 0x06 || c.G != 0x05 || c.B != 0x04 || c.A != 0xFF {
+		t.Fatalf("top-right pixel = %+v, want RGBA(06,05,04,FF)", c)
+	}
+	if c := img.RGBAAt(0, 1); c != (color.RGBA{}) {
+		t.Fatalf("bottom-left pixel = %+v, want zero value", c)
+	}
+}

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -40,6 +40,9 @@ func (b *X11Backend) GrabFullHash(ctx context.Context) (uint32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("screen/x11: XGetImage: %w", err)
 	}
+	if err := validateX11PixelBuffer(reply.Data, int(w), int(h)); err != nil {
+		return 0, err
+	}
 
 	return crc32.ChecksumIEEE(reply.Data), nil
 }
@@ -73,6 +76,9 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 		drawable, x, y, w, h, planeMask).Reply()
 	if err != nil {
 		return 0, fmt.Errorf("screen/x11: XGetImage: %w", err)
+	}
+	if err := validateX11PixelBuffer(reply.Data, int(w), int(h)); err != nil {
+		return 0, err
 	}
 
 	return crc32.ChecksumIEEE(reply.Data), nil
@@ -142,6 +148,9 @@ func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Imag
 	if err != nil {
 		return nil, fmt.Errorf("screen/x11: XGetImage: %w", err)
 	}
+	if err := validateX11PixelBuffer(reply.Data, int(w), int(h)); err != nil {
+		return nil, err
+	}
 
 	return decodeBGRA(reply.Data, int(w), int(h), int(w)*4), nil
 }
@@ -154,5 +163,13 @@ func (b *X11Backend) Resolution() (int, int, error) {
 // Close closes the X11 connection.
 func (b *X11Backend) Close() error {
 	b.conn.Close()
+	return nil
+}
+
+func validateX11PixelBuffer(data []byte, w, h int) error {
+	expected := w * h * 4
+	if len(data) < expected {
+		return fmt.Errorf("screen/x11: short pixel buffer: got %d bytes, want %d", len(data), expected)
+	}
 	return nil
 }

--- a/screen/x11_test.go
+++ b/screen/x11_test.go
@@ -137,6 +137,8 @@ func TestX11Backend_GrabFullHash(t *testing.T) {
 	expectedHash := crc32.ChecksumIEEE(data)
 
 	b, mc := newStubScreenX11Backend(t, false)
+	b.screen.WidthInPixels = 2
+	b.screen.HeightInPixels = 1
 	mc.GetImageFunc = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
 		return x11.NewMockGetImageCookie(&xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}, nil)
 	}
@@ -154,6 +156,8 @@ func TestX11Backend_GrabFullHash_WithComposite(t *testing.T) {
 	expectedHash := crc32.ChecksumIEEE(data)
 
 	b, mc := newStubScreenX11Backend(t, true)
+	b.screen.WidthInPixels = 2
+	b.screen.HeightInPixels = 1
 	mc.NewIdFunc = func() (uint32, error) {
 		return 100, nil
 	}
@@ -170,7 +174,12 @@ func TestX11Backend_GrabFullHash_WithComposite(t *testing.T) {
 }
 
 func TestX11Backend_GrabRegionHash(t *testing.T) {
-	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	data := []byte{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+		13, 14, 15, 16,
+	}
 	expectedHash := crc32.ChecksumIEEE(data)
 
 	b, mc := newStubScreenX11Backend(t, false)
@@ -200,7 +209,12 @@ func TestX11Backend_GrabRegionHash_EmptyRect(t *testing.T) {
 }
 
 func TestX11Backend_GrabRegionHash_WithComposite(t *testing.T) {
-	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	data := []byte{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+		13, 14, 15, 16,
+	}
 	expectedHash := crc32.ChecksumIEEE(data)
 
 	b, mc := newStubScreenX11Backend(t, true)
@@ -210,7 +224,7 @@ func TestX11Backend_GrabRegionHash_WithComposite(t *testing.T) {
 	mc.GetImageFunc = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
 		return x11.NewMockGetImageCookie(&xproto.GetImageReply{Depth: 24, Visual: 1, Data: data}, nil)
 	}
-	rect := image.Rect(10, 20, 110, 120)
+	rect := image.Rect(0, 0, 2, 2)
 	hash, err := b.GrabRegionHash(context.Background(), rect)
 	if err != nil {
 		t.Fatalf("GrabRegionHash() unexpected error: %v", err)
@@ -376,18 +390,48 @@ func TestX11Backend_Grab_ImageCheck(t *testing.T) {
 	}
 }
 
-func TestX11Backend_Grab_NilImage(t *testing.T) {
-	b, mc := newStubScreenX11Backend(t, false)
-	mc.GetImageFunc = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
-		return x11.NewMockGetImageCookie(&xproto.GetImageReply{Depth: 24, Visual: 1, Data: nil}, nil)
+func TestX11Backend_ShortPixelBufferErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*X11Backend) error
+	}{
+		{
+			name: "Grab",
+			run: func(b *X11Backend) error {
+				_, err := b.Grab(context.Background(), image.Rect(0, 0, 1, 1))
+				return err
+			},
+		},
+		{
+			name: "GrabFullHash",
+			run: func(b *X11Backend) error {
+				_, err := b.GrabFullHash(context.Background())
+				return err
+			},
+		},
+		{
+			name: "GrabRegionHash",
+			run: func(b *X11Backend) error {
+				_, err := b.GrabRegionHash(context.Background(), image.Rect(0, 0, 1, 1))
+				return err
+			},
+		},
 	}
-	rect := image.Rect(0, 0, 10, 10)
-	img, err := b.Grab(context.Background(), rect)
-	if err != nil {
-		t.Fatalf("Grab() unexpected error: %v", err)
-	}
-	// Nil data should result in an empty image
-	if img == nil {
-		t.Fatal("Grab() returned nil image for nil data")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, mc := newStubScreenX11Backend(t, false)
+			mc.GetImageFunc = func(format byte, drawable xproto.Drawable, x, y int16, width, height uint16, planeMask uint32) x11.GetImageCookie {
+				return x11.NewMockGetImageCookie(&xproto.GetImageReply{Depth: 24, Visual: 1, Data: []byte{1, 2, 3}}, nil)
+			}
+			if tc.name == "GrabFullHash" {
+				b.screen.WidthInPixels = 1
+				b.screen.HeightInPixels = 1
+			}
+			err := tc.run(b)
+			if err == nil || !strings.Contains(err.Error(), "short pixel buffer") {
+				t.Fatalf("%s() error = %v, want short pixel buffer error", tc.name, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Validate X11 pixel buffers before decoding or hashing\n- Keep decode helpers safe on short data and add regression tests for truncated replies\n- Verified with go test ./screen ./find and full go test ./...