### PR TITLE
fix(screen): respect cancellation in resolution probing

### DIFF
--- a/screen/screen.go
+++ b/screen/screen.go
@@ -34,9 +34,15 @@ func ResolutionWithContext(ctx context.Context, sc Screenshotter) (int, int, err
 	if r, ok := sc.(Resolver); ok {
 		return r.Resolution()
 	}
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
+	}
 	img, err := sc.Grab(ctx, image.Rect(0, 0, 0, 0))
 	if err != nil {
 		return 0, 0, fmt.Errorf("screen: resolution probe: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
 	}
 	b := img.Bounds()
 	if b.Dx() == 0 || b.Dy() == 0 {

--- a/screen/screen_test.go
+++ b/screen/screen_test.go
@@ -1,0 +1,49 @@
+package screen
+
+import (
+	"context"
+	"errors"
+	"image"
+	"testing"
+)
+
+type resolutionCancelScreenshotter struct {
+	img    image.Image
+	cancel context.CancelFunc
+}
+
+func (s *resolutionCancelScreenshotter) cancelOnce() {
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+func (s *resolutionCancelScreenshotter) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+	s.cancelOnce()
+	return s.img, nil
+}
+
+func (s *resolutionCancelScreenshotter) GrabFullHash(ctx context.Context) (uint32, error) {
+	return 0, nil
+}
+
+func (s *resolutionCancelScreenshotter) GrabRegionHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
+	return 0, nil
+}
+
+func (s *resolutionCancelScreenshotter) Close() error { return nil }
+
+func TestResolutionWithContext_CanceledAfterGrab(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	img := image.NewRGBA(image.Rect(0, 0, 11, 7))
+	sc := &resolutionCancelScreenshotter{img: img, cancel: cancel}
+
+	w, h, err := ResolutionWithContext(ctx, sc)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ResolutionWithContext error = %v, want context.Canceled", err)
+	}
+	if w != 0 || h != 0 {
+		t.Fatalf("ResolutionWithContext returned %dx%d on cancellation, want 0x0", w, h)
+	}
+}


### PR DESCRIPTION
- Return context cancellation from screen resolution probes when cancellation happens during the grab\n- Add a regression test that cancels from inside Grab\n- Verified with go test ./...