### PR TITLE
fix(run): preserve empty quoted script args

### DIFF
--- a/cmd/pf/extra.go
+++ b/cmd/pf/extra.go
@@ -132,23 +132,28 @@ func splitShell(s string) ([]string, error) {
 	var cur strings.Builder
 	inQuote := byte(0)
 	escaped := false
+	tokenStarted := false
 	emit := func() {
-		if cur.Len() > 0 {
+		if tokenStarted {
 			out = append(out, cur.String())
 			cur.Reset()
+			tokenStarted = false
 		}
 	}
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
 		if escaped {
+			tokenStarted = true
 			cur.WriteByte(ch)
 			escaped = false
 			continue
 		}
 		switch ch {
 		case '\\':
+			tokenStarted = true
 			escaped = true
 		case '\'', '"':
+			tokenStarted = true
 			if inQuote == 0 {
 				inQuote = ch
 				continue
@@ -160,11 +165,13 @@ func splitShell(s string) ([]string, error) {
 			cur.WriteByte(ch)
 		case ' ', '\t':
 			if inQuote != 0 {
+				tokenStarted = true
 				cur.WriteByte(ch)
 				continue
 			}
 			emit()
 		default:
+			tokenStarted = true
 			cur.WriteByte(ch)
 		}
 	}

--- a/cmd/pf/extra_test.go
+++ b/cmd/pf/extra_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitShellPreservesEmptyQuotedArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "empty double quoted arg",
+			line: `input type ""`,
+			want: []string{"input", "type", ""},
+		},
+		{
+			name: "empty single quoted arg",
+			line: `window find title=''`,
+			want: []string{"window", "find", "title="},
+		},
+		{
+			name: "multiple empty args",
+			line: `input type "" ''`,
+			want: []string{"input", "type", "", ""},
+		},
+		{
+			name: "quoted empty prefix keeps token",
+			line: `input type ""suffix`,
+			want: []string{"input", "type", "suffix"},
+		},
+		{
+			name: "quoted empty suffix keeps token",
+			line: `input type prefix""`,
+			want: []string{"input", "type", "prefix"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := splitShell(tt.line)
+			if err != nil {
+				t.Fatalf("splitShell(%q) error = %v", tt.line, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("splitShell(%q) = %#v, want %#v", tt.line, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- preserve intentionally empty quoted arguments in pf run scripts
- add focused splitShell coverage for empty single- and double-quoted tokens

## Verification
- CGO_ENABLED=0 go test ./cmd/pf -run TestSplitShellPreservesEmptyQuotedArgs -count=1
- CGO_ENABLED=0 go test -short ./cmd/pf
- CGO_ENABLED=0 go test -short ./...
