### PR TITLE
fix(input): honor cancellation in wl-virtual backend

### DIFF
--- a/input/wl_virtual.go
+++ b/input/wl_virtual.go
@@ -170,6 +170,10 @@ func (b *WlVirtualBackend) ptrFrame() error {
 // MouseMove moves the pointer to absolute position (x, y) in the compositor's
 // output coordinate space (i.e. sway display pixels).
 func (b *WlVirtualBackend) MouseMove(ctx context.Context, x, y int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -187,7 +191,11 @@ func (b *WlVirtualBackend) MouseMove(ctx context.Context, x, y int) error {
 	return b.ptrFrame()
 }
 
-func (b *WlVirtualBackend) button(code, state uint32) error {
+func (b *WlVirtualBackend) button(ctx context.Context, code, state uint32) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -216,12 +224,12 @@ func btnCode(button int) uint32 {
 
 // MouseDown presses a mouse button.
 func (b *WlVirtualBackend) MouseDown(ctx context.Context, button int) error {
-	return b.button(btnCode(button), 1)
+	return b.button(ctx, btnCode(button), 1)
 }
 
 // MouseUp releases a mouse button.
 func (b *WlVirtualBackend) MouseUp(ctx context.Context, button int) error {
-	return b.button(btnCode(button), 0)
+	return b.button(ctx, btnCode(button), 0)
 }
 
 // MouseClick moves to (x,y) then clicks the given button.
@@ -254,6 +262,9 @@ func (b *WlVirtualBackend) Type(ctx context.Context, s string) error {
 
 func (b *WlVirtualBackend) TypeContext(ctx context.Context, s string) error {
 	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	actions, err := ParseKeySend(s)
@@ -266,6 +277,10 @@ func (b *WlVirtualBackend) TypeContext(ctx context.Context, s string) error {
 // KeyDown presses and holds a key. Modifier keys update the compositor's
 // modifier state; other keys are held until released with KeyUp.
 func (b *WlVirtualBackend) KeyDown(ctx context.Context, key string) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.kbd.pressKey(key)
@@ -273,6 +288,10 @@ func (b *WlVirtualBackend) KeyDown(ctx context.Context, key string) error {
 
 // KeyUp releases a previously held key.
 func (b *WlVirtualBackend) KeyUp(ctx context.Context, key string) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.kbd.releaseKey(key)
@@ -281,7 +300,11 @@ func (b *WlVirtualBackend) KeyUp(ctx context.Context, key string) error {
 // scroll sends an axis event for the given number of discrete scroll notches.
 // axis 0 = vertical, axis 1 = horizontal. Positive values scroll down/right;
 // negative values scroll up/left.
-func (b *WlVirtualBackend) scroll(axis uint32, clicks int) error {
+func (b *WlVirtualBackend) scroll(ctx context.Context, axis uint32, clicks int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -302,30 +325,35 @@ func (b *WlVirtualBackend) scroll(axis uint32, clicks int) error {
 
 // ScrollUp scrolls the mouse wheel up by the given number of notches.
 func (b *WlVirtualBackend) ScrollUp(ctx context.Context, clicks int) error {
-	return b.scroll(0, -clicks)
+	return b.scroll(ctx, 0, -clicks)
 }
 
 // ScrollDown scrolls the mouse wheel down by the given number of notches.
 func (b *WlVirtualBackend) ScrollDown(ctx context.Context, clicks int) error {
-	return b.scroll(0, clicks)
+	return b.scroll(ctx, 0, clicks)
 }
 
 // ScrollLeft scrolls the mouse wheel left by the given number of notches.
 func (b *WlVirtualBackend) ScrollLeft(ctx context.Context, clicks int) error {
-	return b.scroll(1, -clicks)
+	return b.scroll(ctx, 1, -clicks)
 }
 
 // ScrollRight scrolls the mouse wheel right by the given number of notches.
 func (b *WlVirtualBackend) ScrollRight(ctx context.Context, clicks int) error {
-	return b.scroll(1, clicks)
+	return b.scroll(ctx, 1, clicks)
 }
 
 func (b *WlVirtualBackend) PointerLocation(ctx context.Context) (int, int, error) {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
+	}
 	return 0, 0, fmt.Errorf("input/wl-virtual: pointer location unsupported")
 }
 
 func (b *WlVirtualBackend) Sync(ctx context.Context) error {
-	return nil
+	ctx = normalizeContext(ctx)
+	return ctx.Err()
 }
 
 // Close closes the Wayland connection. Safe to call multiple times and in any

--- a/input/wl_virtual_test.go
+++ b/input/wl_virtual_test.go
@@ -4,6 +4,7 @@
 package input
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nskaggs/perfuncted/internal/wl"
@@ -84,5 +85,81 @@ func TestScroll_SignConvention(t *testing.T) {
 	downValue := int32(3 * 15 * 256)
 	if downValue != 11520 {
 		t.Errorf("3 notches down = %d, want 11520", downValue)
+	}
+}
+
+func TestWlVirtualBackend_CanceledContextShortCircuitsMethods(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := &WlVirtualBackend{}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "MouseMove",
+			run:  func() error { return b.MouseMove(ctx, 1, 2) },
+		},
+		{
+			name: "MouseClick",
+			run:  func() error { return b.MouseClick(ctx, 1, 2, 1) },
+		},
+		{
+			name: "MouseDown",
+			run:  func() error { return b.MouseDown(ctx, 1) },
+		},
+		{
+			name: "MouseUp",
+			run:  func() error { return b.MouseUp(ctx, 1) },
+		},
+		{
+			name: "TypeContext",
+			run:  func() error { return b.TypeContext(ctx, "A{ctrl+a}") },
+		},
+		{
+			name: "KeyDown",
+			run:  func() error { return b.KeyDown(ctx, "a") },
+		},
+		{
+			name: "KeyUp",
+			run:  func() error { return b.KeyUp(ctx, "a") },
+		},
+		{
+			name: "ScrollUp",
+			run:  func() error { return b.ScrollUp(ctx, 1) },
+		},
+		{
+			name: "ScrollDown",
+			run:  func() error { return b.ScrollDown(ctx, 1) },
+		},
+		{
+			name: "ScrollLeft",
+			run:  func() error { return b.ScrollLeft(ctx, 1) },
+		},
+		{
+			name: "ScrollRight",
+			run:  func() error { return b.ScrollRight(ctx, 1) },
+		},
+		{
+			name: "Sync",
+			run:  func() error { return b.Sync(ctx) },
+		},
+		{
+			name: "PointerLocation",
+			run: func() error {
+				_, _, err := b.PointerLocation(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(); err != context.Canceled {
+				t.Fatalf("%s canceled error = %v, want context.Canceled", tt.name, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- return canceled context errors before wl-virtual pointer, keyboard, scroll, sync, and pointer-location work
- pass context through button and scroll helpers
- add regression coverage that canceled calls short-circuit an empty backend instead of touching Wayland state

## Verification
- CGO_ENABLED=0 go test ./input -run TestWlVirtualBackend_CanceledContextShortCircuitsMethods -count=1
- CGO_ENABLED=0 go test -short ./input
- CGO_ENABLED=0 go test -short ./...
