### PR TITLE
fix(input): honor cancellation in wl-input-method wrapper

### DIFF
--- a/input/wl_input_method.go
+++ b/input/wl_input_method.go
@@ -131,6 +131,10 @@ func (b *WlInputMethodBackend) Type(ctx context.Context, s string) error {
 // The input-method protocol (commit_string) requires compositor-side activation
 // which is unreliable in headless CI environments.
 func (b *WlInputMethodBackend) TypeContext(ctx context.Context, s string) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other != nil {
 		return b.other.Type(ctx, s)
 	}
@@ -139,60 +143,100 @@ func (b *WlInputMethodBackend) TypeContext(ctx context.Context, s string) error 
 
 // Delegate other methods to the underlying backend when present.
 func (b *WlInputMethodBackend) KeyDown(ctx context.Context, key string) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: KeyDown unsupported (no subordinate backend)")
 	}
 	return b.other.KeyDown(ctx, key)
 }
 func (b *WlInputMethodBackend) KeyUp(ctx context.Context, key string) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: KeyUp unsupported (no subordinate backend)")
 	}
 	return b.other.KeyUp(ctx, key)
 }
 func (b *WlInputMethodBackend) MouseMove(ctx context.Context, x, y int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: MouseMove unsupported (no subordinate backend)")
 	}
 	return b.other.MouseMove(ctx, x, y)
 }
 func (b *WlInputMethodBackend) MouseClick(ctx context.Context, x, y, button int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: MouseClick unsupported (no subordinate backend)")
 	}
 	return b.other.MouseClick(ctx, x, y, button)
 }
 func (b *WlInputMethodBackend) MouseDown(ctx context.Context, button int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: MouseDown unsupported (no subordinate backend)")
 	}
 	return b.other.MouseDown(ctx, button)
 }
 func (b *WlInputMethodBackend) MouseUp(ctx context.Context, button int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: MouseUp unsupported (no subordinate backend)")
 	}
 	return b.other.MouseUp(ctx, button)
 }
 func (b *WlInputMethodBackend) ScrollUp(ctx context.Context, clicks int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: ScrollUp unsupported (no subordinate backend)")
 	}
 	return b.other.ScrollUp(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollDown(ctx context.Context, clicks int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: ScrollDown unsupported (no subordinate backend)")
 	}
 	return b.other.ScrollDown(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollLeft(ctx context.Context, clicks int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: ScrollLeft unsupported (no subordinate backend)")
 	}
 	return b.other.ScrollLeft(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollRight(ctx context.Context, clicks int) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other == nil {
 		return fmt.Errorf("input/wl-im: ScrollRight unsupported (no subordinate backend)")
 	}
@@ -200,6 +244,10 @@ func (b *WlInputMethodBackend) ScrollRight(ctx context.Context, clicks int) erro
 }
 
 func (b *WlInputMethodBackend) PointerLocation(ctx context.Context) (int, int, error) {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
+	}
 	if b.other == nil {
 		return 0, 0, fmt.Errorf("input/wl-im: pointer location unsupported (no subordinate backend)")
 	}
@@ -207,6 +255,10 @@ func (b *WlInputMethodBackend) PointerLocation(ctx context.Context) (int, int, e
 }
 
 func (b *WlInputMethodBackend) Sync(ctx context.Context) error {
+	ctx = normalizeContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if b.other != nil {
 		return b.other.Sync(ctx)
 	}

--- a/input/wl_input_method_test.go
+++ b/input/wl_input_method_test.go
@@ -5,6 +5,7 @@ package input
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/nskaggs/perfuncted/internal/wl"
@@ -117,6 +118,82 @@ func TestWlInputMethodBackend_Delegate_NoOther(t *testing.T) {
 	// errors when other is nil.
 	// This requires a real Wayland connection, so we just verify the error path.
 	t.Log("Delegation test requires real Wayland connection; skipping full test")
+}
+
+func TestWlInputMethodBackend_CanceledContextShortCircuitsNoOther(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := &WlInputMethodBackend{}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "TypeContext",
+			run:  func() error { return b.TypeContext(ctx, "text") },
+		},
+		{
+			name: "KeyDown",
+			run:  func() error { return b.KeyDown(ctx, "a") },
+		},
+		{
+			name: "KeyUp",
+			run:  func() error { return b.KeyUp(ctx, "a") },
+		},
+		{
+			name: "MouseMove",
+			run:  func() error { return b.MouseMove(ctx, 1, 2) },
+		},
+		{
+			name: "MouseClick",
+			run:  func() error { return b.MouseClick(ctx, 1, 2, 1) },
+		},
+		{
+			name: "MouseDown",
+			run:  func() error { return b.MouseDown(ctx, 1) },
+		},
+		{
+			name: "MouseUp",
+			run:  func() error { return b.MouseUp(ctx, 1) },
+		},
+		{
+			name: "ScrollUp",
+			run:  func() error { return b.ScrollUp(ctx, 1) },
+		},
+		{
+			name: "ScrollDown",
+			run:  func() error { return b.ScrollDown(ctx, 1) },
+		},
+		{
+			name: "ScrollLeft",
+			run:  func() error { return b.ScrollLeft(ctx, 1) },
+		},
+		{
+			name: "ScrollRight",
+			run:  func() error { return b.ScrollRight(ctx, 1) },
+		},
+		{
+			name: "Sync",
+			run:  func() error { return b.Sync(ctx) },
+		},
+		{
+			name: "PointerLocation",
+			run: func() error {
+				_, _, err := b.PointerLocation(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(); err != context.Canceled {
+				t.Fatalf("%s canceled error = %v, want context.Canceled", tt.name, err)
+			}
+		})
+	}
 }
 
 func TestTypeContext_Chunking(t *testing.T) {


### PR DESCRIPTION
## Summary
- return canceled context errors before wl-input-method delegation or unsupported fallback errors
- make Sync respect canceled contexts when no subordinate backend exists
- add no-subordinate regression coverage for all wrapper methods

## Verification
- CGO_ENABLED=0 go test ./input -run TestWlInputMethodBackend_CanceledContextShortCircuitsNoOther -count=1
- CGO_ENABLED=0 go test -short ./input
- CGO_ENABLED=0 go test -short ./...
