### PR TITLE
fix(clipboard): preserve extra trailing newlines

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -77,7 +77,7 @@ func (c *extCmdClipboard) Get(ctx context.Context) (string, error) {
 	}
 	// Normalize trailing-newline differences between backends by trimming a
 	// single trailing '\n'. This keeps behaviour consistent for callers.
-	return strings.TrimRight(out.String(), "\n"), nil
+	return strings.TrimSuffix(out.String(), "\n"), nil
 }
 
 func (c *extCmdClipboard) Set(ctx context.Context, text string) error {

--- a/clipboard/open_test.go
+++ b/clipboard/open_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 
 	"github.com/nskaggs/perfuncted/internal/executil"
@@ -81,5 +82,36 @@ func TestOpen_PrefersX11WhenXclipAvailable(t *testing.T) {
 	}
 	if _, ok := cb.(*extCmdClipboard); !ok {
 		t.Fatalf("clipboard type = %T, want *extCmdClipboard", cb)
+	}
+}
+
+func TestExtCmdClipboardGetTrimsOnlyOneTrailingNewline(t *testing.T) {
+	oldCmd := executil.CommandContext
+	defer func() { executil.CommandContext = oldCmd }()
+
+	var lastCmd *exec.Cmd
+	executil.CommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, "printf", "hello\n\n")
+		lastCmd = cmd
+		return cmd
+	}
+
+	cb := &extCmdClipboard{
+		getCmd: []string{"fake-get"},
+		env:    []string{"WAYLAND_DISPLAY=wayland-test"},
+	}
+
+	got, err := cb.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "hello\n" {
+		t.Fatalf("Get() = %q, want %q", got, "hello\n")
+	}
+	if lastCmd == nil {
+		t.Fatal("CommandContext was not called")
+	}
+	if !reflect.DeepEqual(lastCmd.Env, cb.env) {
+		t.Fatalf("command env = %v, want %v", lastCmd.Env, cb.env)
 	}
 }


### PR DESCRIPTION
## Summary
- trim only one trailing newline from external clipboard command output
- add regression coverage for clipboard content ending in multiple newlines
- verify the captured runtime environment still gets assigned to the command

## Verification
- CGO_ENABLED=0 go test ./clipboard -run TestExtCmdClipboardGetTrimsOnlyOneTrailingNewline -count=1
- CGO_ENABLED=0 go test -short ./clipboard
- CGO_ENABLED=0 go test -short ./...
