### PR TITLE
fix: harden Wayland output strings and pre-poll cancellation

### DIFF
--- a/find/find.go
+++ b/find/find.go
@@ -213,7 +213,7 @@ func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, 
 		attempt := 0
 		for {
 			if err := contextErr(ctx); err != nil {
-				return 0, err
+				return initial, err
 			}
 			h, err := GrabHash(ctx, sc, rect, newHash)
 			if err != nil {
@@ -243,7 +243,7 @@ func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, 
 
 	for {
 		if err := contextErr(ctx); err != nil {
-			return 0, err
+			return initial, err
 		}
 		h, err := GrabHash(ctx, sc, rect, newHash)
 		if err != nil {

--- a/find/find_context_cancel_test.go
+++ b/find/find_context_cancel_test.go
@@ -70,6 +70,25 @@ func TestWaitForChange_CanceledContextAfterGrab(t *testing.T) {
 	}
 }
 
+func TestWaitForChange_CanceledContextBeforeGrabReturnsInitial(t *testing.T) {
+	img := solidRGBA(color.RGBA{G: 255, A: 255})
+	initial := PixelHash(img, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sc := &cancelOnGrabScreenshotter{img: img}
+
+	got, err := WaitForChange(ctx, sc, image.Rect(0, 0, 4, 4), initial, 10*time.Millisecond, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForChange error = %v, want context.Canceled", err)
+	}
+	if got != initial {
+		t.Fatalf("WaitForChange returned %08x, want initial hash %08x", got, initial)
+	}
+	if sc.grabs != 0 {
+		t.Fatalf("WaitForChange grabbed %d frames after context cancellation, want 0", sc.grabs)
+	}
+}
+
 func TestWaitForNoChange_CanceledContextAfterGrab(t *testing.T) {
 	img := solidRGBA(color.RGBA{B: 255, A: 255})
 	want := PixelHash(img, nil)

--- a/output/wayland.go
+++ b/output/wayland.go
@@ -146,15 +146,18 @@ func readWlString(data []byte, off int) (string, int, bool) {
 	}
 	n := int(wl.Uint32(data[off : off+4]))
 	off += 4
-	if n <= 0 || off+n > len(data)+1 {
+	if n <= 0 || off+n > len(data) {
 		return "", off, false
 	}
 	end := off + n - 1
-	if end > len(data) {
+	if end >= len(data) || data[end] != 0 {
 		return "", off, false
 	}
 	raw := string(data[off:end])
 	padded := (n + 3) &^ 3
+	if off+int(padded) > len(data) {
+		return "", off, false
+	}
 	return raw, off + int(padded), true
 }
 

--- a/output/wayland_test.go
+++ b/output/wayland_test.go
@@ -1,0 +1,88 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/nskaggs/perfuncted/internal/wl"
+)
+
+func wlStringData(s string) []byte {
+	n := uint32(len(s) + 1)
+	padded := (n + 3) &^ 3
+	out := make([]byte, 4+int(padded))
+	wl.PutUint32(out[0:4], n)
+	copy(out[4:], s)
+	return out
+}
+
+func TestReadWlString(t *testing.T) {
+	t.Parallel()
+
+	data := wlStringData("HDMI-A-1")
+
+	got, next, ok := readWlString(data, 0)
+	if !ok {
+		t.Fatal("readWlString returned ok=false")
+	}
+	if got != "HDMI-A-1" {
+		t.Fatalf("string = %q, want %q", got, "HDMI-A-1")
+	}
+	if next != len(data) {
+		t.Fatalf("next = %d, want %d", next, len(data))
+	}
+}
+
+func TestReadWlStringRejectsMalformedData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "missing nul terminator",
+			data: func() []byte {
+				data := make([]byte, 8)
+				wl.PutUint32(data[0:4], 4)
+				copy(data[4:], "abcd")
+				return data
+			}(),
+		},
+		{
+			name: "missing padding bytes",
+			data: func() []byte {
+				data := make([]byte, 6)
+				wl.PutUint32(data[0:4], 2)
+				data[4] = 'x'
+				data[5] = 0
+				return data
+			}(),
+		},
+		{
+			name: "length extends beyond data",
+			data: func() []byte {
+				data := make([]byte, 8)
+				wl.PutUint32(data[0:4], 8)
+				return data
+			}(),
+		},
+		{
+			name: "zero length",
+			data: func() []byte {
+				data := make([]byte, 4)
+				wl.PutUint32(data[0:4], 0)
+				return data
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, next, ok := readWlString(tt.data, 0); ok {
+				t.Fatalf("readWlString(%v) = %q, next=%d, ok=true; want ok=false", tt.data, got, next)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- require Wayland strings to include their terminating NUL byte
- reject Wayland string payloads whose padded length exceeds the event data
- return WaitForChange's supplied initial hash if the context is canceled before the first poll, avoiding a zero-hash timeout result under slow scheduling
- add parser coverage plus cancellation regression coverage

## Verification
- CGO_ENABLED=0 go test ./output -run 'TestReadWlString' -count=1
- CGO_ENABLED=0 go test ./find -run 'TestWaitForChange_(CanceledContextBeforeGrabReturnsInitial|TimeoutReturnsLastHash)' -count=100
- CGO_ENABLED=0 go test -short ./output
- CGO_ENABLED=0 go test -short ./...
