### PR TITLE
fix(find): return initial hash on no-change precancel

### DIFF
--- a/find/find.go
+++ b/find/find.go
@@ -294,7 +294,7 @@ func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Recta
 		attempt := 0
 		for {
 			if err := contextErr(ctx); err != nil {
-				return 0, err
+				return last, err
 			}
 			img, err := sc.Grab(ctx, rect)
 			if err != nil {
@@ -363,7 +363,7 @@ func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Recta
 
 	for {
 		if err := contextErr(ctx); err != nil {
-			return 0, err
+			return last, err
 		}
 		img, err := sc.Grab(ctx, rect)
 		if err != nil {

--- a/find/find_context_cancel_test.go
+++ b/find/find_context_cancel_test.go
@@ -104,6 +104,38 @@ func TestWaitForNoChange_CanceledContextAfterGrab(t *testing.T) {
 	}
 }
 
+func TestWaitForNoChange_CanceledContextBeforeGrabReturnsInitial(t *testing.T) {
+	img := solidRGBA(color.RGBA{B: 255, A: 255})
+	initial := PixelHash(img, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		poll time.Duration
+	}{
+		{name: "fixed poll", poll: 10 * time.Millisecond},
+		{name: "adaptive poll", poll: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &cancelOnGrabScreenshotter{img: img}
+
+			got, err := WaitForNoChangeFrom(ctx, sc, image.Rect(0, 0, 4, 4), initial, 2, tt.poll, nil)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("WaitForNoChange error = %v, want context.Canceled", err)
+			}
+			if got != initial {
+				t.Fatalf("WaitForNoChange returned %08x, want initial hash %08x", got, initial)
+			}
+			if sc.grabs != 0 {
+				t.Fatalf("WaitForNoChange grabbed %d frames after context cancellation, want 0", sc.grabs)
+			}
+		})
+	}
+}
+
 func TestWaitForFn_CanceledContextAfterGrab(t *testing.T) {
 	img := solidRGBA(color.RGBA{R: 200, G: 100, B: 50, A: 255})
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- return the supplied initial hash when WaitForNoChangeFrom sees a canceled context before its first grab
- cover both fixed-poll and adaptive-poll pre-cancel paths
- assert no screenshot grab occurs after pre-cancellation

## Verification
- CGO_ENABLED=0 go test ./find -run TestWaitForNoChange_CanceledContextBeforeGrabReturnsInitial -count=100
- CGO_ENABLED=0 go test -short ./find
- CGO_ENABLED=0 go test -short ./...
