### PR TITLE
fix(window): propagate wait find errors

### DIFF
--- a/window/find.go
+++ b/window/find.go
@@ -52,6 +52,9 @@ func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duratio
 		if err == nil {
 			return info, nil
 		}
+		if !errors.Is(err, ErrWindowNotFound) {
+			return Info{}, err
+		}
 		select {
 		case <-ctx.Done():
 			return Info{}, fmt.Errorf("wait for window %q: %w", match.String(), ctx.Err())

--- a/window/find_test.go
+++ b/window/find_test.go
@@ -2,6 +2,7 @@ package window
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"strings"
 	"testing"
@@ -69,6 +70,16 @@ func TestWaitForMatchZeroPoll(t *testing.T) {
 	_, err := WaitForMatch(ctx, m, Match{TitleContains: "hello"}, 0)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestWaitForMatchPropagatesManagerError(t *testing.T) {
+	want := errors.New("list failed")
+	m := &errIterManager{err: want}
+
+	_, err := WaitForMatch(context.Background(), m, Match{TitleContains: "hello"}, 0)
+	if !errors.Is(err, want) {
+		t.Fatalf("WaitForMatch error = %v, want %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make WaitForMatch propagate manager/list errors instead of masking them as timeouts
- keep ErrWindowNotFound as the only retryable wait condition
- add regression coverage for a failing window manager iterator

## Verification
- CGO_ENABLED=0 go test ./window -run TestWaitForMatchPropagatesManagerError -count=1
- CGO_ENABLED=0 go test -short ./window
- CGO_ENABLED=0 go test -short ./...
