### PR TITLE
fix(window): skip wait iteration after precancel

### DIFF
--- a/window/find.go
+++ b/window/find.go
@@ -48,6 +48,9 @@ func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duratio
 	defer ticker.Stop()
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return Info{}, fmt.Errorf("wait for window %q: %w", match.String(), err)
+		}
 		info, err := Find(ctx, m, match)
 		if err == nil {
 			return info, nil
@@ -74,6 +77,9 @@ func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Du
 	defer ticker.Stop()
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("wait for window close %q: %w", match.String(), err)
+		}
 		_, err := Find(ctx, m, match)
 		if err != nil {
 			// Only a true "window not found" result means the window closed

--- a/window/find_test.go
+++ b/window/find_test.go
@@ -40,6 +40,16 @@ func (f *fakeManager) Unfullscreen(ctx context.Context, _ string) error     { re
 func (f *fakeManager) Restore(ctx context.Context, _ string) error          { return nil }
 func (f *fakeManager) Close() error                                         { return nil }
 
+type countingManager struct {
+	fakeManager
+	iterations int
+}
+
+func (m *countingManager) IterateWindows(ctx context.Context) iter.Seq2[Info, error] {
+	m.iterations++
+	return m.fakeManager.IterateWindows(ctx)
+}
+
 func TestFindByTitle_FindsMatch(t *testing.T) {
 	m := &fakeManager{wins: []Info{{ID: 1, Title: "Hello World"}, {ID: 2, Title: "Other"}}}
 	w, err := FindByTitle(context.Background(), m, "world")
@@ -83,6 +93,20 @@ func TestWaitForMatchPropagatesManagerError(t *testing.T) {
 	}
 }
 
+func TestWaitForMatchCanceledContextSkipsIteration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := &countingManager{}
+
+	_, err := WaitForMatch(ctx, m, Match{TitleContains: "hello"}, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForMatch error = %v, want context.Canceled", err)
+	}
+	if m.iterations != 0 {
+		t.Fatalf("WaitForMatch iterated %d times after context cancellation, want 0", m.iterations)
+	}
+}
+
 func TestWaitForMatchCloseZeroPoll(t *testing.T) {
 	m := &fakeManager{wins: []Info{{ID: 1, Title: "Hello World"}}}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -91,5 +115,19 @@ func TestWaitForMatchCloseZeroPoll(t *testing.T) {
 	err := WaitForMatchClose(ctx, m, Match{TitleContains: "hello"}, 0)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestWaitForMatchCloseCanceledContextSkipsIteration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := &countingManager{fakeManager: fakeManager{wins: []Info{{ID: 1, Title: "Hello World"}}}}
+
+	err := WaitForMatchClose(ctx, m, Match{TitleContains: "hello"}, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForMatchClose error = %v, want context.Canceled", err)
+	}
+	if m.iterations != 0 {
+		t.Fatalf("WaitForMatchClose iterated %d times after context cancellation, want 0", m.iterations)
 	}
 }


### PR DESCRIPTION
## Summary
- check canceled contexts before WaitForMatch and WaitForMatchClose call into the manager
- avoid one extra manager iteration after a wait has already been canceled
- add regression coverage for both match and close waits

## Verification
- CGO_ENABLED=0 go test ./window -run 'TestWaitForMatch(Close)?CanceledContextSkipsIteration' -count=1
- CGO_ENABLED=0 go test -short ./window
- CGO_ENABLED=0 go test -short ./...
