### PR TITLE
fix(env): let overlays replace key-only entries

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -44,11 +44,12 @@ func Merge(base []string, overlays ...string) []string {
 	}
 
 	out := make([]string, 0, len(base)+len(overlays))
-	seen := make(map[string]bool, len(base)+len(overlays))
 	for _, kv := range base {
 		i := strings.Index(kv, "=")
 		if i < 0 {
-			// keep malformed entries
+			if _, overr := overMap[kv]; overr {
+				continue
+			}
 			out = append(out, kv)
 			continue
 		}
@@ -58,13 +59,11 @@ func Merge(base []string, overlays ...string) []string {
 			continue
 		}
 		out = append(out, kv)
-		seen[k] = true
 	}
 	// append overlays in order
 	for _, k := range overKeys {
 		v := overMap[k]
 		out = append(out, k+"="+v)
-		seen[k] = true
 	}
 	return out
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -75,6 +75,36 @@ func TestMergeLastOverrideWins(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayReplacesKeyOnlyBaseEntry(t *testing.T) {
+	t.Parallel()
+
+	got := Merge([]string{"FOO", "BAR=1"}, "FOO=2")
+	want := []string{"BAR=1", "FOO=2"}
+	if len(got) != len(want) {
+		t.Fatalf("Merge returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Merge[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestMergePreservesKeyOnlyBaseEntryWithoutOverlay(t *testing.T) {
+	t.Parallel()
+
+	got := Merge([]string{"FOO", "BAR=1"})
+	want := []string{"FOO", "BAR=1"}
+	if len(got) != len(want) {
+		t.Fatalf("Merge returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Merge[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func envMap(kvs []string) map[string]string {
 	m := make(map[string]string)
 	for _, kv := range kvs {


### PR DESCRIPTION
## Summary
- treat key-only base env entries as replaceable by overlays for the same key
- preserve key-only entries when no overlay targets them
- remove the unused seen bookkeeping in Merge

## Verification
- CGO_ENABLED=0 go test ./internal/env -run 'TestMerge(OverlayReplacesKeyOnlyBaseEntry|PreservesKeyOnlyBaseEntryWithoutOverlay)' -count=1
- CGO_ENABLED=0 go test -short ./internal/env
- CGO_ENABLED=0 go test -short ./...
