### PR TITLE
Optimize window matching hot path

### DIFF
--- a/window/find.go
+++ b/window/find.go
@@ -16,10 +16,10 @@ func clampPoll(poll time.Duration) time.Duration {
 
 // Find returns the first window matching match.
 func Find(ctx context.Context, m Manager, match Match) (Info, error) {
-	return find(ctx, m, match, match.String())
+	return find(ctx, m, CompileMatch(match), match.String())
 }
 
-func find(ctx context.Context, m Manager, match Match, label string) (Info, error) {
+func find(ctx context.Context, m Manager, match Matcher, label string) (Info, error) {
 	for w, err := range m.IterateWindows(ctx) {
 		if err != nil {
 			return Info{}, err
@@ -34,7 +34,7 @@ func find(ctx context.Context, m Manager, match Match, label string) (Info, erro
 // FindByTitle returns the first window whose title contains substr
 // (case-insensitive). Error messages are standardized for callers.
 func FindByTitle(ctx context.Context, m Manager, substr string) (Info, error) {
-	return find(ctx, m, Match{TitleContains: substr}, substr)
+	return find(ctx, m, CompileMatch(Match{TitleContains: substr}), substr)
 }
 
 // WaitFor blocks until a window matching pattern is found, or ctx expires.
@@ -44,14 +44,16 @@ func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration)
 
 // WaitForMatch blocks until a window matching match is found, or ctx expires.
 func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duration) (Info, error) {
+	compiled := CompileMatch(match)
+	label := match.String()
 	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return Info{}, fmt.Errorf("wait for window %q: %w", match.String(), err)
+			return Info{}, fmt.Errorf("wait for window %q: %w", label, err)
 		}
-		info, err := Find(ctx, m, match)
+		info, err := find(ctx, m, compiled, label)
 		if err == nil {
 			return info, nil
 		}
@@ -60,7 +62,7 @@ func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duratio
 		}
 		select {
 		case <-ctx.Done():
-			return Info{}, fmt.Errorf("wait for window %q: %w", match.String(), ctx.Err())
+			return Info{}, fmt.Errorf("wait for window %q: %w", label, ctx.Err())
 		case <-ticker.C:
 		}
 	}
@@ -73,14 +75,16 @@ func WaitForClose(ctx context.Context, m Manager, pattern string, poll time.Dura
 
 // WaitForMatchClose blocks until no window matches match, or ctx expires.
 func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Duration) error {
+	compiled := CompileMatch(match)
+	label := match.String()
 	ticker := time.NewTicker(clampPoll(poll))
 	defer ticker.Stop()
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("wait for window close %q: %w", match.String(), err)
+			return fmt.Errorf("wait for window close %q: %w", label, err)
 		}
-		_, err := Find(ctx, m, match)
+		_, err := find(ctx, m, compiled, label)
 		if err != nil {
 			// Only a true "window not found" result means the window closed
 			// successfully. Any other error (I/O failure, context cancellation)
@@ -93,7 +97,7 @@ func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Du
 		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("wait for window close %q: %w", match.String(), ctx.Err())
+			return fmt.Errorf("wait for window close %q: %w", label, ctx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/window/find_bench_test.go
+++ b/window/find_bench_test.go
@@ -15,6 +15,16 @@ func BenchmarkMatchMatches_TitleContains(b *testing.B) {
 	}
 }
 
+func BenchmarkMatcherMatches_TitleContains(b *testing.B) {
+	info := Info{ID: 1, Title: "Firefox Web Browser", AppID: "org.mozilla.firefox", Active: true}
+	matcher := CompileMatch(Match{TitleContains: "firefox"})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = matcher.Matches(info)
+	}
+}
+
 func BenchmarkMatchMatches_TitleExact(b *testing.B) {
 	info := Info{ID: 1, Title: "Firefox Web Browser", AppID: "org.mozilla.firefox"}
 	m := Match{TitleExact: "firefox web browser"}

--- a/window/match.go
+++ b/window/match.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // Match describes a window selection predicate.
@@ -23,9 +24,67 @@ type Match struct {
 	VisibleOnly   bool
 }
 
+// Matcher is a compiled Match with cached normalized fields for repeated use.
+//
+// Compile a Match once when you expect to apply it to many windows, such as in
+// polling loops or full-window scans.
+type Matcher struct {
+	Match
+
+	titleContainsLower string
+}
+
+type matchCacheKey struct {
+	TitleContains string
+	TitleExact    string
+	AppID         string
+	Class         string
+	PID           int32
+	HasPID        bool
+	ID            uint64
+	HasID         bool
+	Active        bool
+	HasActive     bool
+	Minimized     bool
+	HasMinimized  bool
+	Maximized     bool
+	HasMaximized  bool
+	Fullscreen    bool
+	HasFullscreen bool
+	VisibleOnly   bool
+}
+
+var compiledMatchCache sync.Map
+
+// CompileMatch returns a reusable matcher with cached normalized text fields.
+func CompileMatch(m Match) Matcher {
+	key := matchCacheKeyFromMatch(m)
+	if cached, ok := compiledMatchCache.Load(key); ok {
+		return cached.(Matcher)
+	}
+	compiled := Matcher{
+		Match:              m,
+		titleContainsLower: strings.ToLower(m.TitleContains),
+	}
+	actual, _ := compiledMatchCache.LoadOrStore(key, compiled)
+	return actual.(Matcher)
+}
+
 // Matches reports whether info satisfies m.
 func (m Match) Matches(info Info) bool {
-	if m.TitleContains != "" && !strings.Contains(strings.ToLower(info.Title), strings.ToLower(m.TitleContains)) {
+	if m.TitleContains == "" {
+		return Matcher{Match: m}.matches(info)
+	}
+	return CompileMatch(m).matches(info)
+}
+
+// Matches reports whether info satisfies m.
+func (m Matcher) Matches(info Info) bool {
+	return m.matches(info)
+}
+
+func (m Matcher) matches(info Info) bool {
+	if m.TitleContains != "" && !strings.Contains(strings.ToLower(info.Title), m.titleContainsLower) {
 		return false
 	}
 	if m.TitleExact != "" && !strings.EqualFold(info.Title, m.TitleExact) {
@@ -59,6 +118,41 @@ func (m Match) Matches(info Info) bool {
 		return false
 	}
 	return true
+}
+
+func matchCacheKeyFromMatch(m Match) matchCacheKey {
+	key := matchCacheKey{
+		TitleContains: m.TitleContains,
+		TitleExact:    m.TitleExact,
+		AppID:         m.AppID,
+		Class:         m.Class,
+		VisibleOnly:   m.VisibleOnly,
+	}
+	if m.PID != nil {
+		key.HasPID = true
+		key.PID = *m.PID
+	}
+	if m.ID != nil {
+		key.HasID = true
+		key.ID = *m.ID
+	}
+	if m.Active != nil {
+		key.HasActive = true
+		key.Active = *m.Active
+	}
+	if m.Minimized != nil {
+		key.HasMinimized = true
+		key.Minimized = *m.Minimized
+	}
+	if m.Maximized != nil {
+		key.HasMaximized = true
+		key.Maximized = *m.Maximized
+	}
+	if m.Fullscreen != nil {
+		key.HasFullscreen = true
+		key.Fullscreen = *m.Fullscreen
+	}
+	return key
 }
 
 // String returns a compact human-readable representation of m.

--- a/window/match_extra_test.go
+++ b/window/match_extra_test.go
@@ -393,6 +393,32 @@ func TestMatch_Matches_EmptyMatchAll(t *testing.T) {
 	}
 }
 
+func TestCompileMatch_Matches(t *testing.T) {
+	active := true
+	info := Info{
+		ID:        7,
+		Title:     "Exact Title",
+		AppID:     "org.example",
+		Class:     "Example",
+		PID:       42,
+		Active:    true,
+		Minimized: false,
+	}
+	match := Match{
+		TitleContains: "exact",
+		AppID:         "org.example",
+		Class:         "example",
+		Active:        &active,
+	}
+	compiled := CompileMatch(match)
+	if !compiled.Matches(info) {
+		t.Fatal("compiled matcher should match the same window as Match.Matches")
+	}
+	if !match.Matches(info) {
+		t.Fatal("Match.Matches should match the same window")
+	}
+}
+
 // ── Match.String — all fields ─────────────────────────────────────────────────
 
 func TestMatchString_AllFields(t *testing.T) {


### PR DESCRIPTION
Cache compiled window matchers and reuse them across find/wait loops.