### PR TITLE
Fix screen capture and wait loop edge cases

### DIFF
--- a/bundle_screen.go
+++ b/bundle_screen.go
@@ -162,7 +162,9 @@ func (s ScreenBundle) WaitForSettle(ctx context.Context, rect image.Rectangle, a
 	if err != nil {
 		return 0, err
 	}
-	action()
+	if action != nil {
+		action()
+	}
 	changed, err := find.WaitForChange(ctx, s.Screenshotter, rect, before, poll, nil)
 	if err != nil {
 		return 0, err

--- a/find/find.go
+++ b/find/find.go
@@ -286,10 +286,9 @@ func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Recta
 		cur := color.RGBAModel.Convert(img.At(b.Min.X, b.Min.Y)).(color.RGBA)
 		if sentinelSet && cur != sentinel {
 			sentinel = cur
-			last = 0 // force mismatch on next full hash
 			streak = 0
 			// We skip the hash but must continue polling until stable.
-			return false, 0, nil
+			return false, last, nil
 		}
 		sentinel = cur
 		sentinelSet = true

--- a/find/find_nochange_return_test.go
+++ b/find/find_nochange_return_test.go
@@ -1,0 +1,43 @@
+package find
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+	"time"
+)
+
+// TestWaitForNoChange_TimeoutReturnsLastHash verifies that WaitForNoChangeFrom
+// returns the last computed hash on timeout instead of zero when the fast
+// sentinel path keeps skipping full hashes.
+func TestWaitForNoChange_TimeoutReturnsLastHash(t *testing.T) {
+	want := PixelHash(solidRGBA(color.RGBA{R: 0x12, G: 0x34, B: 0x56, A: 0xff}), nil)
+
+	tests := []struct {
+		name string
+		poll time.Duration
+	}{
+		{name: "fixed poll", poll: 5 * time.Millisecond},
+		{name: "adaptive poll", poll: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &changingScreenshotter{}
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			got, err := WaitForNoChangeFrom(ctx, sc, image.Rect(0, 0, 4, 4), want, 5, tc.poll, nil)
+			if err == nil {
+				t.Fatal("WaitForNoChangeFrom: expected timeout error, got nil")
+			}
+			if got == 0 {
+				t.Fatal("WaitForNoChangeFrom: returned 0 on timeout; want last observed hash")
+			}
+			if got != want {
+				t.Fatalf("WaitForNoChangeFrom: timeout returned %08x, want %08x", got, want)
+			}
+		})
+	}
+}

--- a/perfuncted_screen_bundle_test.go
+++ b/perfuncted_screen_bundle_test.go
@@ -175,6 +175,31 @@ func TestScreenBundle_WaitForNoChangeFrom(t *testing.T) {
 	}
 }
 
+func TestScreenBundle_WaitForSettleNilAction(t *testing.T) {
+	red := solidRedImage(4, 4)
+	blue := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			blue.SetRGBA(x, y, color.RGBA{B: 255, A: 255})
+		}
+	}
+
+	sc := &pftest.Screenshotter{Frames: []image.Image{red, blue, blue, blue}}
+	pf := newTestPF(sc)
+	defer pf.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	h, err := pf.Screen.WaitForSettle(ctx, image.Rect(0, 0, 4, 4), nil, 2, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForSettle(nil): %v", err)
+	}
+	if h == 0 {
+		t.Fatal("WaitForSettle(nil): returned zero hash")
+	}
+}
+
 func TestScreenBundle_FindColor(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
 	// Place a blue pixel at (5, 5).

--- a/screen/extcapture.go
+++ b/screen/extcapture.go
@@ -176,7 +176,11 @@ func (b *ExtCaptureBackend) GrabRegionHash(ctx context.Context, rect image.Recta
 	var hash uint32
 	if err := b.grabInternal(ctx, func(pixels []byte, w, h, stride int) error {
 		// Crop rect to the buffer bounds.
-		r := rect.Intersect(image.Rect(0, 0, w, h))
+		scale := int(b.outputScale)
+		if scale <= 0 {
+			scale = 1
+		}
+		r := logicalRectToPhysical(rect, scale).Intersect(image.Rect(0, 0, w, h))
 		if r.Empty() {
 			hash = 0
 			return nil
@@ -212,7 +216,7 @@ func (b *ExtCaptureBackend) Grab(ctx context.Context, rect image.Rectangle) (ima
 		if scale <= 0 {
 			scale = 1
 		}
-		phys := image.Rect(rect.Min.X*scale, rect.Min.Y*scale, rect.Max.X*scale, rect.Max.Y*scale)
+		phys := logicalRectToPhysical(rect, scale)
 		outImg = decodeBGRARect(pixels, w, h, stride, phys)
 		return nil
 	}); err != nil {

--- a/screen/kwinshot.go
+++ b/screen/kwinshot.go
@@ -24,41 +24,23 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
-// GrabFullHash returns a fast pixel hash of the entire screen.
-func (b *KWinShotBackend) GrabFullHash(ctx context.Context) (uint32, error) {
-	img, err := b.Grab(ctx, image.Rect(0, 0, 0, 0))
-	if err != nil {
-		// KWin CaptureArea may fail with empty rect, so we need to get resolution first
-		w, h, err := ResolutionWithContext(ctx, b)
-		if err != nil {
-			return 0, err
-		}
-		img, err = b.Grab(ctx, image.Rect(0, 0, w, h))
-		if err != nil {
-			return 0, err
-		}
-	}
-	return find.PixelHash(img, nil), nil
-}
-
-// GrabRegionHash computes a CRC32 pixel fingerprint for rect. For KWin this
-// currently falls back to a normal Grab + PixelHash.
-func (b *KWinShotBackend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
-	img, err := b.Grab(ctx, rect)
-	if err != nil {
-		return 0, err
-	}
-	return find.PixelHash(img, nil), nil
-}
-
 const (
 	kwinShotDest  = "org.kde.KWin"
 	kwinShotPath  = "/org/kde/KWin/ScreenShot2"
 	kwinShotIface = "org.kde.KWin.ScreenShot2"
 )
 
+type kwinShotTransport interface {
+	CaptureArea(context.Context, image.Rectangle) (image.Image, error)
+	CaptureActiveScreen(context.Context) (image.Image, error)
+}
+
 // KWinShotBackend captures the screen via org.kde.KWin.ScreenShot2.
 type KWinShotBackend struct {
+	transport kwinShotTransport
+}
+
+type kwinDBusTransport struct {
 	conn *dbus.Conn
 	kwin dbus.BusObject
 }
@@ -83,7 +65,7 @@ func NewKWinShotBackendForBus(addr string) (*KWinShotBackend, error) {
 		return nil, fmt.Errorf("screen/kwin: %s not on session bus", kwinShotDest)
 	}
 	obj := conn.Object(kwinShotDest, kwinShotPath)
-	b := &KWinShotBackend{conn: conn, kwin: obj}
+	b := &KWinShotBackend{transport: &kwinDBusTransport{conn: conn, kwin: obj}}
 	// Probe grab: verify the process has screenshot authorization.
 	// KDE Plasma 6 requires explicit per-process permission via the xdg
 	// permission store; this check allows Open() to fall back to the portal.
@@ -93,13 +75,63 @@ func NewKWinShotBackendForBus(addr string) (*KWinShotBackend, error) {
 	return b, nil
 }
 
-// Grab captures rect using CaptureArea. KWin writes pixel data to a Unix pipe;
-// the D-Bus reply carries format metadata in an a{sv}. We close our write-end
-// copy after the synchronous call returns (KWin has already written + closed
-// its dup'd copy by then), then drain the read end.
+// Grab captures rect using CaptureArea. An empty rect requests the active
+// screen capture path. KWin writes pixel data to a Unix pipe; the D-Bus reply
+// carries format metadata in an a{sv}. We close our write-end copy after the
+// synchronous call returns (KWin has already written + closed its dup'd copy
+// by then), then drain the read end.
 func (b *KWinShotBackend) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+	if b == nil || b.transport == nil {
+		return nil, fmt.Errorf("screen/kwin: backend not initialised")
+	}
+	if rect.Empty() {
+		return b.transport.CaptureActiveScreen(ctx)
+	}
+	return b.transport.CaptureArea(ctx, rect)
+}
+
+// GrabFullHash returns a fast pixel hash of the active screen.
+func (b *KWinShotBackend) GrabFullHash(ctx context.Context) (uint32, error) {
+	img, err := b.Grab(ctx, image.Rectangle{})
+	if err != nil {
+		return 0, err
+	}
+	return find.PixelHash(img, nil), nil
+}
+
+// GrabRegionHash computes a CRC32 pixel fingerprint for rect. For KWin this
+// falls back to Grab + PixelHash so the hash stays consistent with GrabFullHash.
+func (b *KWinShotBackend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
+	if rect.Empty() {
+		return b.GrabFullHash(ctx)
+	}
+	img, err := b.Grab(ctx, rect)
+	if err != nil {
+		return 0, err
+	}
+	return find.PixelHash(img, nil), nil
+}
+
+func (t *kwinDBusTransport) CaptureArea(ctx context.Context, rect image.Rectangle) (image.Image, error) {
 	if rect.Empty() {
 		return nil, fmt.Errorf("screen/kwin: empty rectangle")
+	}
+	return t.capture(ctx, kwinShotIface+".CaptureArea", rect,
+		int32(rect.Min.X), int32(rect.Min.Y),
+		uint32(rect.Dx()), uint32(rect.Dy()),
+	)
+}
+
+func (t *kwinDBusTransport) CaptureActiveScreen(ctx context.Context) (image.Image, error) {
+	return t.capture(ctx, kwinShotIface+".CaptureActiveScreen", image.Rectangle{})
+}
+
+func (t *kwinDBusTransport) capture(ctx context.Context, method string, rect image.Rectangle, args ...interface{}) (image.Image, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("screen/kwin: capture canceled: %w", err)
 	}
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -107,22 +139,17 @@ func (b *KWinShotBackend) Grab(ctx context.Context, rect image.Rectangle) (image
 	}
 	defer r.Close()
 
+	callArgs := append(args, map[string]dbus.Variant{}, dbus.UnixFD(w.Fd()))
 	var results map[string]dbus.Variant
-	call := b.kwin.Call(kwinShotIface+".CaptureArea", 0,
-		int32(rect.Min.X), int32(rect.Min.Y),
-		uint32(rect.Dx()), uint32(rect.Dy()),
-		map[string]dbus.Variant{}, // options: use defaults
-		dbus.UnixFD(w.Fd()),
-	)
+	call := t.kwin.Call(method, 0, callArgs...)
 	// Close our copy now; KWin received its own via SCM_RIGHTS and has already
 	// written + closed its copy by the time Call() returns (it's synchronous).
 	w.Close()
 
 	if call.Err != nil {
-		return nil, fmt.Errorf("screen/kwin: CaptureArea: %w", call.Err)
+		return nil, fmt.Errorf("screen/kwin: %s: %w", method, call.Err)
 	}
-	err = call.Store(&results)
-	if err != nil {
+	if err := call.Store(&results); err != nil {
 		return nil, fmt.Errorf("screen/kwin: store results: %w", err)
 	}
 
@@ -146,7 +173,7 @@ func decodeKWinPixels(data []byte, rect image.Rectangle, results map[string]dbus
 		return img, nil
 	}
 
-	w, h := rect.Dx(), rect.Dy()
+	w, h := kwinImageSize(rect, results)
 	stride := w * 4
 	if sv, ok := results["stride"]; ok {
 		if s, ok := sv.Value().(uint32); ok && s > 0 {
@@ -181,6 +208,34 @@ func decodeKWinPixels(data []byte, rect image.Rectangle, results map[string]dbus
 		}
 	}
 	return img, nil
+}
+
+func kwinImageSize(rect image.Rectangle, results map[string]dbus.Variant) (w, h int) {
+	w, h = rect.Dx(), rect.Dy()
+	if results == nil {
+		return w, h
+	}
+	if sv, ok := results["width"]; ok {
+		if s, ok := sv.Value().(uint32); ok && s > 0 {
+			w = int(s)
+		}
+	}
+	if sv, ok := results["height"]; ok {
+		if s, ok := sv.Value().(uint32); ok && s > 0 {
+			h = int(s)
+		}
+	}
+	return w, h
+}
+
+// Resolution returns the active screen dimensions.
+func (b *KWinShotBackend) Resolution() (int, int, error) {
+	img, err := b.Grab(context.Background(), image.Rectangle{})
+	if err != nil {
+		return 0, 0, err
+	}
+	bounds := img.Bounds()
+	return bounds.Dx(), bounds.Dy(), nil
 }
 
 // Close is a no-op; the session bus connection is shared and managed globally.

--- a/screen/kwinshot_test.go
+++ b/screen/kwinshot_test.go
@@ -1,0 +1,154 @@
+package screen
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/nskaggs/perfuncted/find"
+)
+
+type fakeKWinTransport struct {
+	active      image.Image
+	area        image.Image
+	activeErr   error
+	areaErr     error
+	activeCalls int
+	areaCalls   int
+	areaRects   []image.Rectangle
+}
+
+func (f *fakeKWinTransport) CaptureActiveScreen(context.Context) (image.Image, error) {
+	f.activeCalls++
+	if f.activeErr != nil {
+		return nil, f.activeErr
+	}
+	return f.active, nil
+}
+
+func (f *fakeKWinTransport) CaptureArea(_ context.Context, rect image.Rectangle) (image.Image, error) {
+	f.areaCalls++
+	f.areaRects = append(f.areaRects, rect)
+	if f.areaErr != nil {
+		return nil, f.areaErr
+	}
+	return f.area, nil
+}
+
+func solidRGBAForKWin(c color.RGBA, w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.SetRGBA(x, y, c)
+		}
+	}
+	return img
+}
+
+func TestKWinShotBackend_GrabUsesActiveScreenForEmptyRect(t *testing.T) {
+	active := solidRGBAForKWin(color.RGBA{R: 10, G: 20, B: 30, A: 255}, 3, 2)
+	area := solidRGBAForKWin(color.RGBA{R: 90, G: 80, B: 70, A: 255}, 1, 1)
+	transport := &fakeKWinTransport{active: active, area: area}
+	b := &KWinShotBackend{transport: transport}
+
+	img, err := b.Grab(context.Background(), image.Rectangle{})
+	if err != nil {
+		t.Fatalf("Grab(empty): %v", err)
+	}
+	if transport.activeCalls != 1 || transport.areaCalls != 0 {
+		t.Fatalf("calls = active:%d area:%d, want active:1 area:0", transport.activeCalls, transport.areaCalls)
+	}
+	if img.Bounds() != active.Bounds() {
+		t.Fatalf("Grab(empty) bounds = %v, want %v", img.Bounds(), active.Bounds())
+	}
+	if got, want := find.PixelHash(img, nil), find.PixelHash(active, nil); got != want {
+		t.Fatalf("Grab(empty) hash = %08x, want %08x", got, want)
+	}
+}
+
+func TestKWinShotBackend_GrabUsesAreaForNonEmptyRect(t *testing.T) {
+	active := solidRGBAForKWin(color.RGBA{R: 10, G: 20, B: 30, A: 255}, 3, 2)
+	area := solidRGBAForKWin(color.RGBA{R: 90, G: 80, B: 70, A: 255}, 2, 2)
+	transport := &fakeKWinTransport{active: active, area: area}
+	b := &KWinShotBackend{transport: transport}
+	rect := image.Rect(4, 5, 6, 7)
+
+	img, err := b.Grab(context.Background(), rect)
+	if err != nil {
+		t.Fatalf("Grab(rect): %v", err)
+	}
+	if transport.activeCalls != 0 || transport.areaCalls != 1 {
+		t.Fatalf("calls = active:%d area:%d, want active:0 area:1", transport.activeCalls, transport.areaCalls)
+	}
+	if len(transport.areaRects) != 1 || transport.areaRects[0] != rect {
+		t.Fatalf("area rects = %v, want %v", transport.areaRects, rect)
+	}
+	if got, want := img.Bounds(), area.Bounds(); got != want {
+		t.Fatalf("Grab(rect) bounds = %v, want %v", got, want)
+	}
+}
+
+func TestKWinShotBackend_GrabFullHashUsesActiveScreen(t *testing.T) {
+	active := solidRGBAForKWin(color.RGBA{R: 1, G: 2, B: 3, A: 255}, 2, 2)
+	transport := &fakeKWinTransport{active: active}
+	b := &KWinShotBackend{transport: transport}
+
+	got, err := b.GrabFullHash(context.Background())
+	if err != nil {
+		t.Fatalf("GrabFullHash: %v", err)
+	}
+	if transport.activeCalls != 1 || transport.areaCalls != 0 {
+		t.Fatalf("calls = active:%d area:%d, want active:1 area:0", transport.activeCalls, transport.areaCalls)
+	}
+	if want := find.PixelHash(active, nil); got != want {
+		t.Fatalf("GrabFullHash = %08x, want %08x", got, want)
+	}
+}
+
+func TestKWinShotBackend_ResolutionUsesActiveScreen(t *testing.T) {
+	active := solidRGBAForKWin(color.RGBA{R: 4, G: 5, B: 6, A: 255}, 5, 4)
+	transport := &fakeKWinTransport{active: active}
+	b := &KWinShotBackend{transport: transport}
+
+	w, h, err := b.Resolution()
+	if err != nil {
+		t.Fatalf("Resolution: %v", err)
+	}
+	if w != 5 || h != 4 {
+		t.Fatalf("Resolution = %dx%d, want 5x4", w, h)
+	}
+	if transport.activeCalls != 1 || transport.areaCalls != 0 {
+		t.Fatalf("calls = active:%d area:%d, want active:1 area:0", transport.activeCalls, transport.areaCalls)
+	}
+}
+
+func TestDecodeKWinPixels_UsesResultDimensions(t *testing.T) {
+	// Raw ARGB32/BGRA bytes for two opaque pixels.
+	data := []byte{
+		3, 2, 1, 255,
+		6, 5, 4, 255,
+	}
+	results := map[string]dbus.Variant{
+		"width":  dbus.MakeVariant(uint32(2)),
+		"height": dbus.MakeVariant(uint32(1)),
+		"stride": dbus.MakeVariant(uint32(8)),
+		"format": dbus.MakeVariant(uint32(4)),
+	}
+
+	img, err := decodeKWinPixels(data, image.Rectangle{}, results)
+	if err != nil {
+		t.Fatalf("decodeKWinPixels: %v", err)
+	}
+	if got, want := img.Bounds(), image.Rect(0, 0, 2, 1); got != want {
+		t.Fatalf("decodeKWinPixels bounds = %v, want %v", got, want)
+	}
+
+	expected := image.NewRGBA(image.Rect(0, 0, 2, 1))
+	expected.SetRGBA(0, 0, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+	expected.SetRGBA(1, 0, color.RGBA{R: 4, G: 5, B: 6, A: 255})
+	if got, want := find.PixelHash(img, nil), find.PixelHash(expected, nil); got != want {
+		t.Fatalf("decodeKWinPixels hash = %08x, want %08x", got, want)
+	}
+}

--- a/screen/rect.go
+++ b/screen/rect.go
@@ -1,0 +1,18 @@
+package screen
+
+import "image"
+
+// logicalRectToPhysical scales a logical compositor rect into physical pixels.
+//
+// A scale of 1 leaves the rect unchanged. Values <= 0 are treated as 1.
+func logicalRectToPhysical(rect image.Rectangle, scale int) image.Rectangle {
+	if scale <= 1 {
+		return rect
+	}
+	return image.Rect(
+		rect.Min.X*scale,
+		rect.Min.Y*scale,
+		rect.Max.X*scale,
+		rect.Max.Y*scale,
+	)
+}

--- a/screen/rect_test.go
+++ b/screen/rect_test.go
@@ -1,0 +1,28 @@
+package screen
+
+import (
+	"image"
+	"testing"
+)
+
+func TestLogicalRectToPhysical(t *testing.T) {
+	rect := image.Rect(1, 2, 3, 4)
+
+	if got := logicalRectToPhysical(rect, 1); got != rect {
+		t.Fatalf("scale 1 = %v, want %v", got, rect)
+	}
+
+	want := image.Rect(2, 4, 6, 8)
+	if got := logicalRectToPhysical(rect, 2); got != want {
+		t.Fatalf("scale 2 = %v, want %v", got, want)
+	}
+}
+
+func TestLogicalRectToPhysical_NonPositiveScale(t *testing.T) {
+	rect := image.Rect(-2, -3, 4, 5)
+	for _, scale := range []int{0, -1} {
+		if got := logicalRectToPhysical(rect, scale); got != rect {
+			t.Fatalf("scale %d = %v, want %v", scale, got, rect)
+		}
+	}
+}

--- a/screen/wlrscreencopy.go
+++ b/screen/wlrscreencopy.go
@@ -334,7 +334,12 @@ func (b *WlrScreencopyBackend) Grab(ctx context.Context, rect image.Rectangle) (
 			return nil
 		}
 
-		outImg = decodeBGRARect(pixels, int(bi.width), int(bi.height), int(bi.stride), rect)
+		scale := int(b.scale)
+		if scale <= 0 {
+			scale = 1
+		}
+		phys := logicalRectToPhysical(rect, scale)
+		outImg = decodeBGRARect(pixels, int(bi.width), int(bi.height), int(bi.stride), phys)
 		return nil
 	}); err != nil {
 		return nil, err
@@ -583,7 +588,11 @@ func (b *WlrScreencopyBackend) GrabRegionHash(ctx context.Context, rect image.Re
 		// BGRA bytes using the stride.
 		fullW := int(bi.width)
 		fullH := int(bi.height)
-		r := rect.Intersect(image.Rect(0, 0, fullW, fullH))
+		scale := int(b.scale)
+		if scale <= 0 {
+			scale = 1
+		}
+		r := logicalRectToPhysical(rect, scale).Intersect(image.Rect(0, 0, fullW, fullH))
 		if r.Empty() {
 			hash = 0
 			return nil


### PR DESCRIPTION
Rolled up the remaining screen and wait-loop fixes:

- scale logical rects in the Wayland raw capture backends
- route KWin empty-rect captures through the active-screen API and use reported raw dimensions when decoding
- keep WaitForNoChangeFrom timeout returns stable instead of zero when the sentinel fast path skips hashes
- make ScreenBundle.WaitForSettle tolerate a nil action

Verification:
- go test ./find
- go test .
- go test <screen file list excluding x11_integration_test.go>
- Benchmarks: screen/pixels_bench_test.go and find/find_bench_test.go