### PR TITLE
Fix unresolved Wayland socket handling and speed up WaitForImage

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -102,11 +102,5 @@ func captureRuntimeEnv(rt env.Runtime) []string {
 }
 
 func isWaylandRuntime(rt env.Runtime) bool {
-	if rt.Get("XDG_SESSION_TYPE") == "wayland" {
-		return true
-	}
-	if rt.Get("WAYLAND_DISPLAY") != "" && rt.Display() == "" {
-		return true
-	}
-	return false
+	return rt.SocketPath() != ""
 }

--- a/clipboard/open_test.go
+++ b/clipboard/open_test.go
@@ -43,6 +43,7 @@ func TestOpen_PrefersWaylandWhenAvailable(t *testing.T) {
 	defer func() { executil.CommandContext = oldCmd }()
 
 	// Simulate Wayland session.
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
 	t.Setenv("WAYLAND_DISPLAY", "wayland-2")
 	os.Unsetenv("DISPLAY")
 
@@ -52,6 +53,37 @@ func TestOpen_PrefersWaylandWhenAvailable(t *testing.T) {
 	}
 	if _, ok := cb.(*extCmdClipboard); !ok {
 		t.Fatalf("clipboard type = %T, want *extCmdClipboard", cb)
+	}
+}
+
+func TestOpen_FallsBackWhenWaylandSocketUnresolvable(t *testing.T) {
+	oldLP := executil.LookPath
+	executil.LookPath = func(name string) (string, error) {
+		if name == "xclip" {
+			return "/nonexistent/xclip", nil
+		}
+		return "", os.ErrNotExist
+	}
+	defer func() { executil.LookPath = oldLP }()
+
+	oldCmd := executil.CommandContext
+	executil.CommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "exit 0")
+	}
+	defer func() { executil.CommandContext = oldCmd }()
+
+	t.Setenv("WAYLAND_DISPLAY", "wayland-3")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("DISPLAY", ":0")
+
+	cb, err := Open()
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got, ok := cb.(*extCmdClipboard); !ok {
+		t.Fatalf("clipboard type = %T, want *extCmdClipboard", cb)
+	} else if len(got.getCmd) == 0 || got.getCmd[0] != "xclip" {
+		t.Fatalf("clipboard getCmd = %v, want xclip", got.getCmd)
 	}
 }
 

--- a/internal/env/runtime.go
+++ b/internal/env/runtime.go
@@ -2,9 +2,10 @@ package env
 
 import (
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
 // Runtime is a snapshot of the environment used to route automation requests
@@ -103,20 +104,10 @@ func (r Runtime) Display() string {
 	return r.Get("DISPLAY")
 }
 
-// SocketPath resolves the Wayland socket path for the runtime snapshot.
+// SocketPath resolves the Wayland socket path for the runtime snapshot, or
+// returns the empty string when the socket cannot be resolved.
 func (r Runtime) SocketPath() string {
-	sock := r.Get("WAYLAND_DISPLAY")
-	if sock == "" {
-		return ""
-	}
-	if filepath.IsAbs(sock) {
-		return sock
-	}
-	xrd := r.Get("XDG_RUNTIME_DIR")
-	if xrd == "" {
-		return sock
-	}
-	return filepath.Join(xrd, sock)
+	return wl.ResolveSocketPath(r.Get("WAYLAND_DISPLAY"), r.Get("XDG_RUNTIME_DIR"))
 }
 
 func (r Runtime) clone() Runtime {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -38,13 +38,23 @@ func WaitForPixelColor(sc find.Screenshotter, rect image.Rectangle, target color
 func WaitForImage(sc find.Screenshotter, template image.Image, method string, timeout time.Duration) ([]MatchResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	// Probe full-screen bounds by asking for a zero rect grab; many backends
-	// return the full-output image for a zero rect.
-	img, err := sc.Grab(ctx, image.Rect(0, 0, 0, 0))
-	if err != nil {
-		return nil, fmt.Errorf("util: probe screen bounds: %w", err)
+	searchArea := image.Rectangle{}
+	if r, ok := sc.(interface {
+		Resolution() (int, int, error)
+	}); ok {
+		if w, h, err := r.Resolution(); err == nil && w > 0 && h > 0 {
+			searchArea = image.Rect(0, 0, w, h)
+		}
 	}
-	searchArea := img.Bounds()
+	if searchArea.Empty() {
+		// Probe full-screen bounds by asking for a zero rect grab; many backends
+		// return the full-output image for a zero rect.
+		img, err := sc.Grab(ctx, image.Rect(0, 0, 0, 0))
+		if err != nil {
+			return nil, fmt.Errorf("util: probe screen bounds: %w", err)
+		}
+		searchArea = img.Bounds()
+	}
 	switch method {
 	case "", "exact":
 		r, err := find.WaitForLocate(ctx, sc, searchArea, template, 200*time.Millisecond)

--- a/internal/util/waitforimage_opt_test.go
+++ b/internal/util/waitforimage_opt_test.go
@@ -1,0 +1,167 @@
+package util_test
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/draw"
+	"testing"
+	"time"
+
+	"github.com/nskaggs/perfuncted/internal/util"
+)
+
+type countedScreenshotter struct {
+	img   image.Image
+	grabs int
+}
+
+func (s *countedScreenshotter) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+	s.grabs++
+	return s.img, nil
+}
+
+func (s *countedScreenshotter) GrabFullHash(ctx context.Context) (uint32, error) {
+	return 0, nil
+}
+
+func (s *countedScreenshotter) GrabRegionHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
+	return 0, nil
+}
+
+func (s *countedScreenshotter) Close() error { return nil }
+
+type countedResolutionScreenshotter struct {
+	countedScreenshotter
+}
+
+func (s *countedResolutionScreenshotter) Resolution() (int, int, error) {
+	b := s.img.Bounds()
+	return b.Dx(), b.Dy(), nil
+}
+
+func waitForImageFixture() (image.Image, image.Image) {
+	big := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	ref := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	ref.SetRGBA(0, 0, color.RGBA{R: 10, A: 255})
+	ref.SetRGBA(1, 0, color.RGBA{G: 20, A: 255})
+	ref.SetRGBA(0, 1, color.RGBA{B: 30, A: 255})
+	ref.SetRGBA(1, 1, color.RGBA{R: 40, G: 50, B: 60, A: 255})
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			big.SetRGBA(1+x, 1+y, ref.RGBAAt(x, y))
+		}
+	}
+	return big, ref
+}
+
+func TestWaitForImageUsesResolutionWhenAvailable(t *testing.T) {
+	big, ref := waitForImageFixture()
+	sc := &countedResolutionScreenshotter{countedScreenshotter{img: big}}
+
+	res, err := util.WaitForImage(sc, ref, "exact", 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForImage: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res))
+	}
+	if res[0].Rect != image.Rect(1, 1, 3, 3) {
+		t.Fatalf("unexpected rect: %v", res[0].Rect)
+	}
+	if sc.grabs != 1 {
+		t.Fatalf("Grab calls = %d, want 1", sc.grabs)
+	}
+}
+
+func TestWaitForImageFallsBackWithoutResolution(t *testing.T) {
+	big, ref := waitForImageFixture()
+	sc := &countedScreenshotter{img: big}
+
+	res, err := util.WaitForImage(sc, ref, "exact", 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForImage: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res))
+	}
+	if res[0].Rect != image.Rect(1, 1, 3, 3) {
+		t.Fatalf("unexpected rect: %v", res[0].Rect)
+	}
+	if sc.grabs != 2 {
+		t.Fatalf("Grab calls = %d, want 2", sc.grabs)
+	}
+}
+
+func BenchmarkWaitForImageWithResolution(b *testing.B) {
+	big, ref := waitForImageBenchmarkFixture()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sc := &benchmarkResolutionScreenshotter{benchmarkScreenshotter{img: big}}
+		if _, err := util.WaitForImage(sc, ref, "exact", time.Second); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWaitForImageWithoutResolution(b *testing.B) {
+	big, ref := waitForImageBenchmarkFixture()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sc := &benchmarkScreenshotter{img: big}
+		if _, err := util.WaitForImage(sc, ref, "exact", time.Second); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+type benchmarkScreenshotter struct {
+	img image.Image
+}
+
+func (s *benchmarkScreenshotter) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
+	return cloneImage(s.img), nil
+}
+
+func (s *benchmarkScreenshotter) GrabFullHash(ctx context.Context) (uint32, error) {
+	return 0, nil
+}
+
+func (s *benchmarkScreenshotter) GrabRegionHash(ctx context.Context, rect image.Rectangle) (uint32, error) {
+	return 0, nil
+}
+
+func (s *benchmarkScreenshotter) Close() error { return nil }
+
+type benchmarkResolutionScreenshotter struct {
+	benchmarkScreenshotter
+}
+
+func (s *benchmarkResolutionScreenshotter) Resolution() (int, int, error) {
+	b := s.img.Bounds()
+	return b.Dx(), b.Dy(), nil
+}
+
+func waitForImageBenchmarkFixture() (image.Image, image.Image) {
+	big := image.NewRGBA(image.Rect(0, 0, 640, 480))
+	ref := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	ref.SetRGBA(0, 0, color.RGBA{R: 10, A: 255})
+	ref.SetRGBA(1, 0, color.RGBA{G: 20, A: 255})
+	ref.SetRGBA(0, 1, color.RGBA{B: 30, A: 255})
+	ref.SetRGBA(1, 1, color.RGBA{R: 40, G: 50, B: 60, A: 255})
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			big.SetRGBA(1+x, 1+y, ref.RGBAAt(x, y))
+		}
+	}
+	return big, ref
+}
+
+func cloneImage(img image.Image) image.Image {
+	bounds := img.Bounds()
+	out := image.NewRGBA(image.Rect(0, 0, bounds.Dx(), bounds.Dy()))
+	draw.Draw(out, out.Bounds(), img, bounds.Min, draw.Src)
+	return out
+}

--- a/internal/wl/wl.go
+++ b/internal/wl/wl.go
@@ -199,7 +199,24 @@ func putStr(buf []byte, s string) []byte {
 	return buf
 }
 
-// SocketPath returns the absolute path to the Wayland socket from the environment.
+// ResolveSocketPath resolves a Wayland socket path from WAYLAND_DISPLAY and
+// XDG_RUNTIME_DIR. Relative socket names require XDG_RUNTIME_DIR; otherwise
+// the socket cannot be resolved and the empty string is returned.
+func ResolveSocketPath(waylandDisplay, xdgRuntimeDir string) string {
+	if waylandDisplay == "" {
+		return ""
+	}
+	if filepath.IsAbs(waylandDisplay) {
+		return waylandDisplay
+	}
+	if xdgRuntimeDir == "" {
+		return ""
+	}
+	return filepath.Join(xdgRuntimeDir, waylandDisplay)
+}
+
+// SocketPath returns the resolved absolute path to the Wayland socket from the
+// environment, or the empty string when WAYLAND_DISPLAY cannot be resolved.
 var socketPathOverride string
 
 // SetSocketPathOverride sets an explicit Wayland socket path to use instead
@@ -211,18 +228,7 @@ func SocketPath() string {
 	if socketPathOverride != "" {
 		return socketPathOverride
 	}
-	sock := os.Getenv("WAYLAND_DISPLAY")
-	if sock == "" {
-		return ""
-	}
-	if filepath.IsAbs(sock) {
-		return sock
-	}
-	xrd := os.Getenv("XDG_RUNTIME_DIR")
-	if xrd == "" {
-		return sock
-	}
-	return filepath.Join(xrd, sock)
+	return ResolveSocketPath(os.Getenv("WAYLAND_DISPLAY"), os.Getenv("XDG_RUNTIME_DIR"))
 }
 
 // ── Display ───────────────────────────────────────────────────────────────────

--- a/internal/wl/wl_test.go
+++ b/internal/wl/wl_test.go
@@ -107,6 +107,24 @@ func TestPutStr_PrependToExistingBuffer(t *testing.T) {
 	}
 }
 
+func TestSocketPathReturnsEmptyWithoutRuntimeDir(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	if got := SocketPath(); got != "" {
+		t.Fatalf("SocketPath = %q, want empty", got)
+	}
+}
+
+func TestSocketPathKeepsAbsoluteDisplay(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "/run/user/1000/wayland-1")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	if got := SocketPath(); got != "/run/user/1000/wayland-1" {
+		t.Fatalf("SocketPath = %q, want /run/user/1000/wayland-1", got)
+	}
+}
+
 func TestRawProxy_Dispatch(t *testing.T) {
 	var gotOpcode uint32
 	var gotData []byte

--- a/perfuncted_runtime_test.go
+++ b/perfuncted_runtime_test.go
@@ -69,3 +69,13 @@ func TestRuntimeSocketPathKeepsAbsoluteWaylandDisplay(t *testing.T) {
 		t.Fatalf("SocketPath = %q, want /run/user/1000/wayland-1", got)
 	}
 }
+
+func TestRuntimeSocketPathReturnsEmptyWithoutRuntimeDir(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"WAYLAND_DISPLAY=wayland-0",
+	})
+
+	if got := rt.SocketPath(); got != "" {
+		t.Fatalf("SocketPath = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary\n- resolve relative Wayland sockets only when XDG_RUNTIME_DIR is available, and return empty when the socket cannot be resolved\n- route clipboard backend selection through the resolved socket path instead of raw WAYLAND_DISPLAY heuristics\n- let util.WaitForImage reuse screenshotter resolution when available to skip the initial full-screen probe\n\n## Tests\n- go test ./... (non-integration packages)\n- go test ./internal/util -bench WaitForImage -benchmem -run '^$'\n\n## Notes\n- added regression coverage for unresolved Wayland sockets in env, wl, and clipboard selection\n- added WaitForImage tests that count Grab calls to confirm the probe is skipped when resolution is available