### PR TITLE
Fall back to X11 when Wayland socket is unresolved

### DIFF
--- a/screen/open_test.go
+++ b/screen/open_test.go
@@ -1,0 +1,26 @@
+package screen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nskaggs/perfuncted/internal/env"
+)
+
+func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"DISPLAY=:99",
+		"WAYLAND_DISPLAY=wayland-0",
+	})
+
+	sc, err := OpenRuntime(rt)
+	if err != nil {
+		if !strings.Contains(err.Error(), `screen/x11: connect to display ":99"`) {
+			t.Fatalf("OpenRuntime error = %v, want X11 connection error", err)
+		}
+		return
+	}
+	if _, ok := sc.(*X11Backend); !ok {
+		t.Fatalf("OpenRuntime returned %T, want *X11Backend", sc)
+	}
+}

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -70,6 +70,9 @@ func Open() (Screenshotter, error) {
 
 // OpenRuntime returns the best available Screenshotter for rt.
 func OpenRuntime(rt env.Runtime) (Screenshotter, error) {
+	if display := rt.Display(); display != "" && rt.SocketPath() == "" {
+		return NewX11Backend(display)
+	}
 	switch compositor.DetectRuntime(rt) {
 	case compositor.KDE:
 		if b, err := NewKWinShotBackendForBus(rt.Get("DBUS_SESSION_BUS_ADDRESS")); err == nil {
@@ -120,6 +123,9 @@ func OpenRuntime(rt env.Runtime) (Screenshotter, error) {
 		}
 		if b, err := NewPortalDBusBackendForBus(rt.Get("DBUS_SESSION_BUS_ADDRESS")); err == nil {
 			return b, nil
+		}
+		if display := rt.Display(); display != "" {
+			return NewX11Backend(display)
 		}
 		return nil, fmt.Errorf("screen: unsupported Wayland compositor")
 	}

--- a/window/open_test.go
+++ b/window/open_test.go
@@ -1,0 +1,26 @@
+package window
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nskaggs/perfuncted/internal/env"
+)
+
+func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"DISPLAY=:99",
+		"WAYLAND_DISPLAY=wayland-0",
+	})
+
+	mgr, err := OpenRuntime(rt)
+	if err != nil {
+		if !strings.Contains(err.Error(), `window/x11: connect to display ":99"`) {
+			t.Fatalf("OpenRuntime error = %v, want X11 connection error", err)
+		}
+		return
+	}
+	if _, ok := mgr.(*X11Backend); !ok {
+		t.Fatalf("OpenRuntime returned %T, want *X11Backend", mgr)
+	}
+}

--- a/window/window.go
+++ b/window/window.go
@@ -87,6 +87,9 @@ func Open() (Manager, error) {
 
 // OpenRuntime returns the best available Manager for rt.
 func OpenRuntime(rt env.Runtime) (Manager, error) {
+	if display := rt.Display(); display != "" && rt.SocketPath() == "" {
+		return NewX11Backend(display)
+	}
 	switch compositor.DetectRuntime(rt) {
 	case compositor.KDE:
 		m, err := NewKWinScriptManagerForBus(rt.Get("DBUS_SESSION_BUS_ADDRESS"))
@@ -115,6 +118,9 @@ func OpenRuntime(rt env.Runtime) (Manager, error) {
 	case compositor.Unknown:
 		if m, err := NewWaylandWindowManagerForSocket(rt.SocketPath()); err == nil {
 			return m, nil
+		}
+		if display := rt.Display(); display != "" {
+			return NewX11Backend(display)
 		}
 		return nil, fmt.Errorf("window: unsupported Wayland compositor")
 


### PR DESCRIPTION
## Summary\n- treat DISPLAY+unresolvable Wayland socket as an X11 session in window and screen open paths\n- keep the behavior aligned with the existing output and input selectors\n\n## Tests\n- go test ./... (non-integration packages)\n\n## Notes\n- added regression tests that verify the window and screen open paths hit the X11 branch by checking the returned connection error prefix