### PR TITLE
Matrix integration testing across display environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,42 @@ jobs:
       - name: Run Quality Checks
         run: just quality
 
-  integration:
-    name: Integration (Headless)
+  integration-suite:
+    name: Integration (${{ matrix.display }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        display:
+          - headless-x11
+          - nested-x11
+          - headless-wayland
+          - nested-wayland
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.3"
+          cache: true
+      - uses: taiki-e/install-action@just
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sway openbox xserver-xephyr dbus-x11 libwayland-client0 \
+                                 libwayland-server0 libwlroots-dev libx11-dev libxtst-dev \
+                                 x11-utils xclip wl-clipboard xdg-utils xvfb kwrite featherpad
+      - name: Run Integration Tests
+        run: just test-integration-suite "${{ matrix.display }}"
+      - name: Upload integration logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs-${{ matrix.display }}
+          path: /tmp/perfuncted-logs/**/*.log
+          if-no-files-found: ignore
+
+  integration-session:
+    name: Integration (Session Lifecycle)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,11 +72,44 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y sway openbox dbus-x11 libwayland-client0 libwayland-server0 \
-                                 libwlroots-dev libx11-dev libxtst-dev x11-utils xclip \
-                                 wl-clipboard xdg-utils xvfb kwrite gnome-text-editor featherpad
-      - name: Run Integration Tests
-        run: just test-integration
+          sudo apt-get install -y sway openbox xserver-xephyr dbus-x11 libwayland-client0 \
+                                 libwayland-server0 libwlroots-dev libx11-dev libxtst-dev \
+                                 x11-utils xclip wl-clipboard xdg-utils xvfb kwrite featherpad
+      - name: Run Session Lifecycle Test
+        run: just test-session
+      - name: Upload integration logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs-session
+          path: /tmp/perfuncted-logs/**/*.log
+          if-no-files-found: ignore
+
+  integration-backends:
+    name: Integration (Backends)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.3"
+          cache: true
+      - uses: taiki-e/install-action@just
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sway openbox xserver-xephyr dbus-x11 libwayland-client0 \
+                                 libwayland-server0 libwlroots-dev libx11-dev libxtst-dev \
+                                 x11-utils xclip wl-clipboard xdg-utils xvfb kwrite featherpad
+      - name: Run Backend Integration Tests
+        run: just test-integration-backends
+      - name: Upload integration logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs-backends
+          path: /tmp/perfuncted-logs/**/*.log
+          if-no-files-found: ignore
 
   release-smoke:
     name: Release Smoke Test
@@ -74,4 +141,3 @@ jobs:
           BIN=$(find dist/ -name 'pf' -type f | head -1)
           echo "Testing binary: $BIN"
           just test-release-binary "$BIN"
-

--- a/input/xtest_integration_test.go
+++ b/input/xtest_integration_test.go
@@ -7,18 +7,17 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/nskaggs/perfuncted/input"
+	"github.com/nskaggs/perfuncted/internal/x11test"
 )
 
 // TestMain starts a throwaway Xvfb display for all integration tests in this
 // package, sets DISPLAY, then tears the server down on exit.
 func TestMain(m *testing.M) {
-	display, stop, err := startXvfb()
+	display, stop, err := x11test.StartXvfb()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "input integration: start Xvfb: %v\n", err)
 		os.Exit(1)
@@ -27,39 +26,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	stop()
 	os.Exit(code)
-}
-
-// startXvfb launches Xvfb on a free display number and returns the display
-// string plus a stop function.
-func startXvfb() (display string, stop func(), err error) {
-	const dispNum = 98
-	display = fmt.Sprintf(":%d", dispNum)
-
-	cmd := exec.Command("Xvfb", display, "-screen", "0", "1024x768x24")
-	if err := cmd.Start(); err != nil {
-		return "", nil, fmt.Errorf("exec Xvfb: %w", err)
-	}
-
-	lockFile := fmt.Sprintf("/tmp/.X%d-lock", dispNum)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(lockFile); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, err := os.Stat(lockFile); err != nil {
-		cmd.Process.Kill() //nolint:errcheck
-		return "", nil, fmt.Errorf("Xvfb did not start within 10 s (lock %s not found)", lockFile)
-	}
-
-	stop = func() {
-		cmd.Process.Kill() //nolint:errcheck
-		cmd.Wait()         //nolint:errcheck
-		os.Remove(lockFile)
-		os.Remove(fmt.Sprintf("/tmp/.X11-unix/X%s", strconv.Itoa(dispNum)))
-	}
-	return display, stop, nil
 }
 
 // TestXTestBackend_Integration_Type connects to the Xvfb display and fires

--- a/integration/core_paths_test.go
+++ b/integration/core_paths_test.go
@@ -386,7 +386,7 @@ func TestTypeFast_MatchesType(t *testing.T) {
 	}
 	kbApp := app
 	kbApp.saveFile = kbFile
-	cmdKB, err := launchApp(s.rt, s.session, kbApp, kbApp.extraEnvFor(s.mode)...)
+	cmdKB, err := launchApp(s.rt, kbApp, kbApp.extraEnvFor(s.mode)...)
 	v.NoError(err, "launch keyboard editor")
 	t.Cleanup(func() { terminateCmd(cmdKB, 5*time.Second) })
 
@@ -414,7 +414,7 @@ func TestTypeFast_MatchesType(t *testing.T) {
 	}
 	cbApp := app
 	cbApp.saveFile = cbFile
-	cmdCB, err := launchApp(s.rt, s.session, cbApp, cbApp.extraEnvFor(s.mode)...)
+	cmdCB, err := launchApp(s.rt, cbApp, cbApp.extraEnvFor(s.mode)...)
 	v.NoError(err, "launch clipboard editor")
 	t.Cleanup(func() { terminateCmd(cmdCB, 5*time.Second) })
 
@@ -473,7 +473,7 @@ func TestWindowFocus_SwitchBetweenWindows(t *testing.T) {
 	}
 	appA := app
 	appA.saveFile = fileA
-	cmdA, err := launchApp(s.rt, s.session, appA, appA.extraEnvFor(s.mode)...)
+	cmdA, err := launchApp(s.rt, appA, appA.extraEnvFor(s.mode)...)
 	v.NoError(err, "launch window A")
 	t.Cleanup(func() { terminateCmd(cmdA, 5*time.Second) })
 
@@ -488,7 +488,7 @@ func TestWindowFocus_SwitchBetweenWindows(t *testing.T) {
 	}
 	appB := app
 	appB.saveFile = fileB
-	cmdB, err := launchApp(s.rt, s.session, appB, appB.extraEnvFor(s.mode)...)
+	cmdB, err := launchApp(s.rt, appB, appB.extraEnvFor(s.mode)...)
 	v.NoError(err, "launch window B")
 	t.Cleanup(func() { terminateCmd(cmdB, 5*time.Second) })
 
@@ -538,7 +538,7 @@ func TestWindowClose_VerifiedGoneFromList(t *testing.T) {
 	}
 	closeApp := app
 	closeApp.saveFile = closeFile
-	cmd, err := launchApp(s.rt, s.session, closeApp, closeApp.extraEnvFor(s.mode)...)
+	cmd, err := launchApp(s.rt, closeApp, closeApp.extraEnvFor(s.mode)...)
 	v.NoError(err, "launch editor")
 	t.Cleanup(func() { terminateCmd(cmd, 5*time.Second) })
 
@@ -832,7 +832,7 @@ func TestWindowList_Lifecycle(t *testing.T) {
 	}
 	winApp := app
 	winApp.saveFile = saveFile
-	cmd, err := launchApp(s.rt, s.session, winApp, winApp.extraEnvFor(s.mode)...)
+	cmd, err := launchApp(s.rt, winApp, winApp.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch app: %v", err)
 	}
@@ -957,7 +957,7 @@ func TestFind_WaitForChangeDetectsChange(t *testing.T) {
 	}
 	wfcApp := app
 	wfcApp.saveFile = saveFile
-	cmd, err := launchApp(s.rt, s.session, wfcApp, wfcApp.extraEnvFor(s.mode)...)
+	cmd, err := launchApp(s.rt, wfcApp, wfcApp.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch app: %v", err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nskaggs/perfuncted/input"
 	"github.com/nskaggs/perfuncted/internal/env"
 	"github.com/nskaggs/perfuncted/internal/executil"
+	"github.com/nskaggs/perfuncted/internal/x11test"
 	"github.com/nskaggs/perfuncted/screen"
 	"github.com/nskaggs/perfuncted/window"
 )
@@ -46,14 +47,10 @@ type appSpec struct {
 }
 
 type suite struct {
-	mode displayMode
-	rt   env.Runtime
-	pf   *perfuncted.Perfuncted
-
-	session *perfuncted.Session
-	xvfb    *exec.Cmd
-	xephyr  *exec.Cmd
-	openbox *exec.Cmd
+	mode     displayMode
+	rt       env.Runtime
+	pf       *perfuncted.Perfuncted
+	cleanups []func()
 }
 
 var currentSuite *suite
@@ -130,34 +127,48 @@ func newSuite(mode displayMode) (*suite, error) {
 	traceWriter, traceDelay := traceConfigFromEnv()
 	switch mode {
 	case displayHeadlessX11:
-		display, xvfb, openbox, err := startX11Session()
+		display, stop, err := startHeadlessX11Session()
 		if err != nil {
 			return nil, err
 		}
-		s.xvfb = xvfb
-		s.openbox = openbox
+		s.addCleanup(stop)
 		s.rt = configureX11Runtime(display)
 	case displayNestedX11:
-		display, xephyr, openbox, err := startNestedX11Session()
+		if os.Getenv("DISPLAY") == "" {
+			display, stop, err := x11test.StartXvfb()
+			if err != nil {
+				return nil, fmt.Errorf("start nested x11 host: %w", err)
+			}
+			os.Setenv("DISPLAY", display)
+			s.addCleanup(stop)
+		}
+		display, stop, err := startNestedX11Session()
 		if err != nil {
 			return nil, err
 		}
-		s.xephyr = xephyr
-		s.openbox = openbox
+		s.addCleanup(stop)
 		s.rt = configureX11Runtime(display)
 	case displayHeadlessWayland:
-		sess, err := perfuncted.StartSession(perfuncted.SessionConfig{Resolution: image.Pt(1024, 768)})
+		sess, err := perfuncted.StartSession(sessionConfig("headless-wayland"))
 		if err != nil {
 			return nil, err
 		}
-		s.session = sess
+		s.addCleanup(sess.Stop)
 		s.rt = configureWaylandRuntime(sess)
 	case displayNestedWayland:
-		sess, err := perfuncted.StartNestedSession(perfuncted.SessionConfig{Resolution: image.Pt(1024, 768)})
+		if env.Current().SocketPath() == "" {
+			hostSess, err := perfuncted.StartSession(sessionConfig("nested-wayland-host"))
+			if err != nil {
+				return nil, fmt.Errorf("start nested wayland host: %w", err)
+			}
+			s.addCleanup(hostSess.Stop)
+			s.rt = configureWaylandRuntime(hostSess)
+		}
+		sess, err := perfuncted.StartNestedSession(sessionConfig("nested-wayland-inner"))
 		if err != nil {
 			return nil, err
 		}
-		s.session = sess
+		s.addCleanup(sess.Stop)
 		s.rt = configureWaylandRuntime(sess)
 	default:
 		return nil, fmt.Errorf("unknown PF_TEST_DISPLAY_SERVER=%q", mode)
@@ -175,6 +186,23 @@ func newSuite(mode displayMode) (*suite, error) {
 	}
 	s.pf = pf
 	return s, nil
+}
+
+func (s *suite) addCleanup(fn func()) {
+	if fn != nil {
+		s.cleanups = append(s.cleanups, fn)
+	}
+}
+
+func sessionConfig(role string) perfuncted.SessionConfig {
+	return perfuncted.SessionConfig{
+		Resolution: image.Pt(1024, 768),
+		LogDir:     sessionLogDir(role),
+	}
+}
+
+func sessionLogDir(role string) string {
+	return filepath.Join(os.TempDir(), "perfuncted-logs", fmt.Sprintf("%s-%d", role, os.Getpid()))
 }
 
 func configureX11Runtime(display string) env.Runtime {
@@ -208,12 +236,9 @@ func (s *suite) Close() error {
 	if s.pf != nil {
 		errs = append(errs, s.pf.Close())
 	}
-	if s.session != nil {
-		s.session.Stop()
+	for i := len(s.cleanups) - 1; i >= 0; i-- {
+		s.cleanups[i]()
 	}
-	terminateCmd(s.openbox, 2*time.Second)
-	terminateCmd(s.xephyr, 2*time.Second)
-	terminateCmd(s.xvfb, 2*time.Second)
 	return joinErrors(errs...)
 }
 
@@ -259,90 +284,61 @@ func joinErrors(errs ...error) error {
 	}
 }
 
-func startX11Session() (display string, xvfb *exec.Cmd, openbox *exec.Cmd, err error) {
-	if _, err := executil.LookPath("Xvfb"); err != nil {
-		return "", nil, nil, fmt.Errorf("x11 integration requires Xvfb: %w", err)
-	}
+func startHeadlessX11Session() (display string, stop func(), err error) {
 	if _, err := executil.LookPath("openbox"); err != nil {
-		return "", nil, nil, fmt.Errorf("x11 integration requires openbox: %w", err)
+		return "", nil, fmt.Errorf("x11 integration requires openbox: %w", err)
 	}
 
-	const dispNum = 99
-	display = fmt.Sprintf(":%d", dispNum)
-	xvfb = exec.Command("Xvfb", display, "-screen", "0", "1024x768x24")
-	xvfb.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := xvfb.Start(); err != nil {
-		return "", nil, nil, fmt.Errorf("start Xvfb: %w", err)
+	display, stopXvfb, err := x11test.StartXvfb()
+	if err != nil {
+		return "", nil, err
 	}
 
-	lockFile := fmt.Sprintf("/tmp/.X%d-lock", dispNum)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, statErr := os.Stat(lockFile); statErr == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, statErr := os.Stat(lockFile); statErr != nil {
-		_ = xvfb.Process.Kill()
-		_ = xvfb.Wait()
-		return "", nil, nil, fmt.Errorf("Xvfb did not start within 10s (lock %s not found)", lockFile)
+	openbox, err := startOpenbox(display)
+	if err != nil {
+		stopXvfb()
+		return "", nil, err
 	}
 
-	openbox = exec.Command("openbox")
-	openbox.Env = append(os.Environ(), "DISPLAY="+display)
-	openbox.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := openbox.Start(); err != nil {
-		_ = xvfb.Process.Kill()
-		_ = xvfb.Wait()
-		return "", nil, nil, fmt.Errorf("start openbox: %w", err)
+	stop = func() {
+		terminateCmd(openbox, 2*time.Second)
+		stopXvfb()
 	}
-	time.Sleep(600 * time.Millisecond)
-	return display, xvfb, openbox, nil
+	return display, stop, nil
 }
 
-func startNestedX11Session() (display string, xephyr *exec.Cmd, openbox *exec.Cmd, err error) {
-	if _, err := executil.LookPath("Xephyr"); err != nil {
-		return "", nil, nil, fmt.Errorf("nested x11 integration requires Xephyr: %w", err)
-	}
+func startNestedX11Session() (display string, stop func(), err error) {
 	if _, err := executil.LookPath("openbox"); err != nil {
-		return "", nil, nil, fmt.Errorf("nested x11 integration requires openbox: %w", err)
-	}
-	if os.Getenv("DISPLAY") == "" {
-		return "", nil, nil, fmt.Errorf("nested x11 requires host DISPLAY to be set")
+		return "", nil, fmt.Errorf("x11 integration requires openbox: %w", err)
 	}
 
-	const dispNum = 100
-	display = fmt.Sprintf(":%d", dispNum)
-	xephyr = exec.Command("Xephyr", display, "-screen", "1024x768", "-ac", "-br", "-reset")
-	xephyr.Env = append(os.Environ(), "DISPLAY="+os.Getenv("DISPLAY"))
-	xephyr.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := xephyr.Start(); err != nil {
-		return "", nil, nil, fmt.Errorf("start Xephyr: %w", err)
+	display, stopXephyr, err := x11test.StartXephyr(os.Getenv("DISPLAY"))
+	if err != nil {
+		return "", nil, err
 	}
 
-	lockFile := fmt.Sprintf("/tmp/.X%d-lock", dispNum)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, statErr := os.Stat(lockFile); statErr == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, statErr := os.Stat(lockFile); statErr != nil {
-		terminateCmd(xephyr, 500*time.Millisecond)
-		return "", nil, nil, fmt.Errorf("Xephyr did not start within 10s (lock %s not found)", lockFile)
+	openbox, err := startOpenbox(display)
+	if err != nil {
+		stopXephyr()
+		return "", nil, err
 	}
 
-	openbox = exec.Command("openbox")
+	stop = func() {
+		terminateCmd(openbox, 2*time.Second)
+		stopXephyr()
+	}
+	return display, stop, nil
+}
+
+func startOpenbox(display string) (*exec.Cmd, error) {
+	openbox := exec.Command("openbox")
 	openbox.Env = append(os.Environ(), "DISPLAY="+display)
 	openbox.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := openbox.Start(); err != nil {
-		terminateCmd(xephyr, 500*time.Millisecond)
-		return "", nil, nil, fmt.Errorf("start openbox: %w", err)
+		return nil, fmt.Errorf("start openbox: %w", err)
 	}
 	time.Sleep(600 * time.Millisecond)
-	return display, xephyr, openbox, nil
+	return openbox, nil
 }
 
 func TestIntegration(t *testing.T) {
@@ -392,7 +388,7 @@ func TestSessionLifecycle(t *testing.T) {
 		}
 	}
 
-	cmd, err := launchApp(rt, sess, app, app.extraEnvFor(displayHeadlessWayland)...)
+	cmd, err := launchApp(rt, app, app.extraEnvFor(displayHeadlessWayland)...)
 	if err != nil {
 		t.Fatalf("launch %s: %v", app.name, err)
 	}
@@ -586,7 +582,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 		t.Fatalf("create %s: %v", saveFile, err)
 	}
 
-	cmd, err := launchApp(s.rt, s.session, app, app.extraEnvFor(s.mode)...)
+	cmd, err := launchApp(s.rt, app, app.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch %s: %v", app.name, err)
 	}
@@ -730,7 +726,7 @@ func runEditorScenario(t *testing.T, s *suite, app appSpec) {
 
 func runBrowserScenario(t *testing.T, s *suite, app appSpec) {
 	t.Helper()
-	cmd, err := launchApp(s.rt, s.session, app, app.extraEnvFor(s.mode)...)
+	cmd, err := launchApp(s.rt, app, app.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch %s: %v", app.name, err)
 	}
@@ -764,7 +760,7 @@ func runBrowserScenario(t *testing.T, s *suite, app appSpec) {
 	}
 }
 
-func launchApp(rt env.Runtime, sess *perfuncted.Session, app appSpec, extraEnv ...string) (*exec.Cmd, error) {
+func launchApp(rt env.Runtime, app appSpec, extraEnv ...string) (*exec.Cmd, error) {
 	args := append([]string{}, app.launch[1:]...)
 	if app.saveFile != "" && !app.isBrowser {
 		args = append(args, app.saveFile)
@@ -776,15 +772,12 @@ func launchApp(rt env.Runtime, sess *perfuncted.Session, app appSpec, extraEnv .
 		}
 		args = append(args, "--profile", profileDir)
 		extraEnv = append(extraEnv, "MOZ_DISABLE_CONTENT_SANDBOX=1")
-		if sess != nil {
+		if rt.SocketPath() != "" {
 			extraEnv = append(extraEnv, "MOZ_ENABLE_WAYLAND=1")
 		}
 	}
 
 	baseEnv := rt.EnvList()
-	if sess != nil {
-		baseEnv = sess.Env()
-	}
 	path, err := executil.LookPath(app.launch[0])
 	if err != nil {
 		return nil, err

--- a/integration/iter3_test.go
+++ b/integration/iter3_test.go
@@ -277,7 +277,7 @@ func TestMultiWindow_FindIsolation(t *testing.T) {
 	}
 	appA := app
 	appA.saveFile = fileA
-	cmdA, err := launchApp(s.rt, s.session, appA, appA.extraEnvFor(s.mode)...)
+	cmdA, err := launchApp(s.rt, appA, appA.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch window A: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestMultiWindow_FindIsolation(t *testing.T) {
 	}
 	appB := app
 	appB.saveFile = fileB
-	cmdB, err := launchApp(s.rt, s.session, appB, appB.extraEnvFor(s.mode)...)
+	cmdB, err := launchApp(s.rt, appB, appB.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch window B: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestMultiWindow_WaitForStateIsolation(t *testing.T) {
 	}
 	appA := app
 	appA.saveFile = fileA
-	cmdA, err := launchApp(s.rt, s.session, appA, appA.extraEnvFor(s.mode)...)
+	cmdA, err := launchApp(s.rt, appA, appA.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch window A: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestMultiWindow_WaitForStateIsolation(t *testing.T) {
 	}
 	appB := app
 	appB.saveFile = fileB
-	cmdB, err := launchApp(s.rt, s.session, appB, appB.extraEnvFor(s.mode)...)
+	cmdB, err := launchApp(s.rt, appB, appB.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch window B: %v", err)
 	}
@@ -439,7 +439,7 @@ func TestMultiWindow_ActivateSwitching(t *testing.T) {
 	}
 	appA := app
 	appA.saveFile = fileA
-	cmdA, err := launchApp(s.rt, s.session, appA, appA.extraEnvFor(s.mode)...)
+	cmdA, err := launchApp(s.rt, appA, appA.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch A: %v", err)
 	}
@@ -455,7 +455,7 @@ func TestMultiWindow_ActivateSwitching(t *testing.T) {
 	}
 	appB := app
 	appB.saveFile = fileB
-	cmdB, err := launchApp(s.rt, s.session, appB, appB.extraEnvFor(s.mode)...)
+	cmdB, err := launchApp(s.rt, appB, appB.extraEnvFor(s.mode)...)
 	if err != nil {
 		t.Fatalf("launch B: %v", err)
 	}

--- a/internal/x11test/x11test.go
+++ b/internal/x11test/x11test.go
@@ -1,0 +1,115 @@
+package x11test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nskaggs/perfuncted/internal/executil"
+)
+
+const (
+	startupTimeout = 15 * time.Second
+)
+
+// StartXvfb starts a standalone Xvfb server on a free display.
+func StartXvfb() (display string, stop func(), err error) {
+	return startServer("Xvfb", "", func() []string {
+		return []string{"-screen", "0", "1024x768x24", "-ac"}
+	})
+}
+
+// StartXephyr starts a nested Xephyr server on a free display using hostDisplay.
+func StartXephyr(hostDisplay string) (display string, stop func(), err error) {
+	if hostDisplay == "" {
+		return "", nil, fmt.Errorf("x11test: host DISPLAY not set")
+	}
+	return startServer("Xephyr", hostDisplay, func() []string {
+		return []string{"-screen", "1024x768", "-ac", "-br", "-reset"}
+	})
+}
+
+func startServer(name, hostDisplay string, argsFn func() []string) (display string, stop func(), err error) {
+	if _, err := executil.LookPath(name); err != nil {
+		return "", nil, fmt.Errorf("x11test: %s not found: %w", name, err)
+	}
+
+	var stderr bytes.Buffer
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return "", nil, fmt.Errorf("x11test: create displayfd pipe: %w", err)
+	}
+	defer pr.Close()
+
+	cmd := exec.Command(name, append(argsFn(), "-displayfd", "3")...)
+	if hostDisplay != "" {
+		cmd.Env = append(os.Environ(), "DISPLAY="+hostDisplay)
+	}
+	cmd.ExtraFiles = []*os.File{pw}
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		return "", nil, fmt.Errorf("x11test: start %s: %w", name, err)
+	}
+	_ = pw.Close()
+
+	displayCh := make(chan struct {
+		num int
+		err error
+	}, 1)
+	go func() {
+		var num int
+		_, err := fmt.Fscan(pr, &num)
+		displayCh <- struct {
+			num int
+			err error
+		}{num: num, err: err}
+	}()
+
+	select {
+	case res := <-displayCh:
+		if res.err != nil {
+			stopDisplay(cmd)
+			return "", nil, fmt.Errorf("x11test: %s did not report a display: %w; stderr: %s", name, res.err, strings.TrimSpace(stderr.String()))
+		}
+		display = fmt.Sprintf(":%d", res.num)
+		stop = func() {
+			stopDisplay(cmd)
+		}
+		return display, stop, nil
+	case <-time.After(startupTimeout):
+		stopDisplay(cmd)
+		return "", nil, fmt.Errorf("x11test: %s did not become ready within %s; stderr: %s", name, startupTimeout, strings.TrimSpace(stderr.String()))
+	}
+}
+
+func stopDisplay(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/justfile
+++ b/justfile
@@ -118,37 +118,50 @@ test-unit:
 # Run unit tests (default alias)
 test: test-unit
 
+# Run the shared integration suite in one display mode.
+test-integration-suite MODE:
+    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER={{MODE}} go test -tags=integration ./integration -run '^TestIntegration$' -count=1
+
 # Test the session package lifecycle: creates its own headless session from scratch.
 test-session:
-    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=headless-wayland go test -tags=integration ./integration -run TestSessionLifecycle -count=1
+    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=headless-wayland go test -tags=integration ./integration -run '^TestSessionLifecycle$' -count=1
 
 # Run the shared integration suite against headless X11.
 test-integration-headless-x11:
-    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=headless-x11 go test -tags=integration ./integration -count=1
+    just test-integration-suite headless-x11
 
 # Run the shared integration suite against nested X11.
 test-integration-nested-x11:
-    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=nested-x11 go test -tags=integration ./integration -count=1
+    just test-integration-suite nested-x11
 
 # Integration suite against nested X11 with tracing and slower execution
 test-integration-nested-x11-debug:
-    CGO_ENABLED=0 PF_TRACE_ACTIONS=1 PF_TRACE_DELAY=1000ms PF_TEST_DISPLAY_SERVER=nested-x11 go test -tags=integration ./integration -count=1 -v
+    CGO_ENABLED=0 PF_TRACE_ACTIONS=1 PF_TRACE_DELAY=1000ms PF_TEST_DISPLAY_SERVER=nested-x11 go test -tags=integration ./integration -run '^TestIntegration$' -count=1 -v
 
 # Run the shared integration suite against headless Wayland.
 test-integration-headless-wayland:
-    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=headless-wayland go test -tags=integration ./integration -count=1
+    just test-integration-suite headless-wayland
 
 # Run the shared integration suite against nested Wayland.
 test-integration-nested-wayland:
-    CGO_ENABLED=0 PF_TEST_DISPLAY_SERVER=nested-wayland go test -tags=integration ./integration -count=1
+    just test-integration-suite nested-wayland
 
 # Integration suite against nested Wayland with tracing and slower execution
 test-integration-nested-wayland-debug:
-    CGO_ENABLED=0 PF_TRACE_ACTIONS=1 PF_TRACE_DELAY=1000ms PF_TEST_DISPLAY_SERVER=nested-wayland go test -tags=integration ./integration -count=1 -v
+    CGO_ENABLED=0 PF_TRACE_ACTIONS=1 PF_TRACE_DELAY=1000ms PF_TEST_DISPLAY_SERVER=nested-wayland go test -tags=integration ./integration -run '^TestIntegration$' -count=1 -v
+
+# Run the package-level backend integration tests.
+test-integration-backends:
+    CGO_ENABLED=0 go test -p 1 -tags=integration ./window ./input ./screen ./clipboard -count=1
     
-# Run all integration checks: shared suite plus package-level backend integrations.
-test-integration: test-integration-headless-x11 test-integration-headless-wayland
-    CGO_ENABLED=0 go test -tags=integration ./window ./input ./screen ./clipboard -count=1
+# Run all integration checks: shared suite across every environment plus session and backend coverage.
+test-integration:
+    just test-integration-suite headless-x11
+    just test-integration-suite nested-x11
+    just test-integration-suite headless-wayland
+    just test-integration-suite nested-wayland
+    just test-session
+    just test-integration-backends
 
 # Build the Flatpak bundle
 build-flatpak:
@@ -241,7 +254,7 @@ cleanup-nested:
     @echo "Cleaning up stale temp files and sockets..."
     -for dir in "$$tmpdir"/perfuncted-xdg-*/gvfs; do [ -d "$$dir" ] && fusermount -u "$$dir" 2>/dev/null || true; done
     -rm -rf "$$tmpdir"/perfuncted-xdg-* 2>/dev/null || true
-    -rm -f "$$tmpdir"/perfuncted-logs/*.log "$$tmpdir"/perfuncted-logs/*.res 2>/dev/null || true
+    -rm -rf "$$tmpdir"/perfuncted-logs 2>/dev/null || true
     -rm -f "$$tmpdir"/pf-test-*.png 2>/dev/null || true
     -rm -f "$$tmpdir"/*-kwrite.txt 2>/dev/null || true
     -rm -f "$$tmpdir"/*-featherpad.txt 2>/dev/null || true

--- a/window/x11_integration_test.go
+++ b/window/x11_integration_test.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
 	"testing"
 	"time"
 
+	"github.com/nskaggs/perfuncted/internal/x11test"
 	"github.com/nskaggs/perfuncted/window"
 )
 
@@ -23,7 +22,7 @@ import (
 var sharedBackend *window.X11Backend
 
 func TestMain(m *testing.M) {
-	display, stop, err := startXvfb()
+	display, stop, err := x11test.StartXvfb()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "window integration: start Xvfb: %v\n", err)
 		os.Exit(1)
@@ -41,39 +40,6 @@ func TestMain(m *testing.M) {
 	sharedBackend.Close()
 	stop()
 	os.Exit(code)
-}
-
-// startXvfb launches Xvfb on a free display number and returns the display
-// string plus a stop function.
-func startXvfb() (display string, stop func(), err error) {
-	const dispNum = 99
-	display = fmt.Sprintf(":%d", dispNum)
-
-	cmd := exec.Command("Xvfb", display, "-screen", "0", "1024x768x24")
-	if err := cmd.Start(); err != nil {
-		return "", nil, fmt.Errorf("exec Xvfb: %w", err)
-	}
-
-	lockFile := fmt.Sprintf("/tmp/.X%d-lock", dispNum)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(lockFile); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, err := os.Stat(lockFile); err != nil {
-		cmd.Process.Kill() //nolint:errcheck
-		return "", nil, fmt.Errorf("Xvfb did not start within 10 s (lock %s not found)", lockFile)
-	}
-
-	stop = func() {
-		cmd.Process.Kill() //nolint:errcheck
-		cmd.Wait()         //nolint:errcheck
-		os.Remove(lockFile)
-		os.Remove(fmt.Sprintf("/tmp/.X11-unix/X%s", strconv.Itoa(dispNum)))
-	}
-	return display, stop, nil
 }
 
 // TestX11Backend_Integration_ActiveTitle connects to the Xvfb display and


### PR DESCRIPTION
## Summary
- Run the same integration test body across headless/nested X11 and headless/nested Wayland.
- Split session lifecycle and backend integration checks into separate CI jobs.
- Replace X11 display scanning with displayfd-based startup in the shared X11 helper.

## Validation
- PF_TEST_DISPLAY_SERVER=nested-x11 go test -tags=integration ./integration -run '^TestIntegration$' -count=1 -v
- PF_TEST_DISPLAY_SERVER=headless-x11 go test -tags=integration ./integration -run '^TestIntegration$' -count=1 -v
- PF_TEST_DISPLAY_SERVER=nested-wayland go test -tags=integration ./integration -run '^TestIntegration$' -count=1
- go test -p 1 -tags=integration ./window ./input ./screen ./clipboard -count=1
