### PR TITLE
Harden test coverage for core selector paths

### DIFF
--- a/integration/core_paths_test.go
+++ b/integration/core_paths_test.go
@@ -896,6 +896,33 @@ func TestWindowList_Lifecycle(t *testing.T) {
 	}
 }
 
+// TestOutputList_ReportsGeometry verifies that the output backend returns at
+// least one output with a stable geometry and backend tag in the live session.
+func TestOutputList_ReportsGeometry(t *testing.T) {
+	s := mustSuite(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	outs, err := s.pf.Output.List(ctx)
+	if err != nil {
+		t.Fatalf("Output.List: %v", err)
+	}
+	if len(outs) == 0 {
+		t.Fatal("Output.List returned no outputs")
+	}
+	for i, out := range outs {
+		if out.Name == "" {
+			t.Errorf("output %d missing name: %+v", i, out)
+		}
+		if out.Backend == "" {
+			t.Errorf("output %d missing backend: %+v", i, out)
+		}
+		if out.Geometry.W <= 0 || out.Geometry.H <= 0 {
+			t.Errorf("output %d has invalid geometry: %+v", i, out)
+		}
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Screen resolution sanity check
 // ─────────────────────────────────────────────────────────────────────────────

--- a/output/open_test.go
+++ b/output/open_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/nskaggs/perfuncted/internal/env"
 )
 
+func TestOpenRuntime_NoSessionReturnsError(t *testing.T) {
+	rt := env.FromEnviron([]string{})
+
+	if _, err := OpenRuntime(rt); err == nil {
+		t.Fatal("OpenRuntime succeeded unexpectedly without DISPLAY or Wayland socket")
+	} else if !strings.Contains(err.Error(), "no display or Wayland socket available") {
+		t.Fatalf("OpenRuntime error = %v, want no-session error", err)
+	}
+}
+
 func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	rt := env.FromEnviron([]string{
 		"DISPLAY=:99",
@@ -45,5 +55,23 @@ func TestProbeRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	}
 	if !strings.Contains(got[0].Reason, "socket missing") {
 		t.Fatalf("ProbeRuntime reason = %q, want missing socket fallback", got[0].Reason)
+	}
+}
+
+func TestProbeRuntime_NoSessionReportsUnavailable(t *testing.T) {
+	rt := env.FromEnviron([]string{})
+
+	got := ProbeRuntime(rt)
+	if len(got) != 1 {
+		t.Fatalf("ProbeRuntime len = %d, want 1", len(got))
+	}
+	if got[0].Name != "output" {
+		t.Fatalf("ProbeRuntime name = %q, want output", got[0].Name)
+	}
+	if got[0].Available || got[0].Selected {
+		t.Fatalf("ProbeRuntime available=%v selected=%v, want false/false", got[0].Available, got[0].Selected)
+	}
+	if !strings.Contains(got[0].Reason, "no output source available") {
+		t.Fatalf("ProbeRuntime reason = %q, want no-output-source message", got[0].Reason)
 	}
 }

--- a/perfuncted_output_bundle_test.go
+++ b/perfuncted_output_bundle_test.go
@@ -1,0 +1,82 @@
+package perfuncted_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nskaggs/perfuncted"
+	"github.com/nskaggs/perfuncted/output"
+)
+
+type outputSpyLister struct {
+	listCalls  int
+	closeCalls int
+	ctxValue   any
+	infos      []output.Info
+	err        error
+	closeErr   error
+}
+
+func (o *outputSpyLister) List(ctx context.Context) ([]output.Info, error) {
+	o.listCalls++
+	o.ctxValue = ctx.Value(contextKey{})
+	return o.infos, o.err
+}
+
+func (o *outputSpyLister) Close() error {
+	o.closeCalls++
+	return o.closeErr
+}
+
+func TestOutputBundleListAndClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), contextKey{}, "token")
+	closeErr := errors.New("output close failed")
+	spy := &outputSpyLister{
+		infos: []output.Info{{
+			Name:        "HDMI-A-1",
+			Backend:     "wayland",
+			Geometry:    output.Geometry{X: 0, Y: 0, W: 1920, H: 1080},
+			ResolutionW: 1920,
+			ResolutionH: 1080,
+			Scale:       2,
+		}},
+		closeErr: closeErr,
+	}
+
+	pf := &perfuncted.Perfuncted{
+		Output: perfuncted.OutputBundle{Lister: spy},
+	}
+
+	got, err := pf.Output.List(ctx)
+	if err != nil {
+		t.Fatalf("Output.List: %v", err)
+	}
+	if spy.listCalls != 1 {
+		t.Fatalf("List calls = %d, want 1", spy.listCalls)
+	}
+	if spy.closeCalls != 0 {
+		t.Fatalf("Close calls after List = %d, want 0", spy.closeCalls)
+	}
+	if spy.ctxValue != "token" {
+		t.Fatalf("List context value = %v, want token", spy.ctxValue)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Output.List len = %d, want 1", len(got))
+	}
+	if got[0].Name != "HDMI-A-1" || got[0].Backend != "wayland" {
+		t.Fatalf("Output.List returned %+v, want HDMI-A-1/wayland", got[0])
+	}
+	if got[0].Geometry.W != 1920 || got[0].Geometry.H != 1080 {
+		t.Fatalf("Output.List geometry = %+v, want 1920x1080", got[0].Geometry)
+	}
+
+	if err := pf.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close error = %v, want %v", err, closeErr)
+	}
+	if spy.closeCalls != 1 {
+		t.Fatalf("Close calls after Perfuncted.Close = %d, want 1", spy.closeCalls)
+	}
+}

--- a/screen/open_test.go
+++ b/screen/open_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/nskaggs/perfuncted/internal/env"
 )
 
+func TestOpenRuntime_NoSessionReturnsError(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=" + t.TempDir(),
+	})
+
+	if _, err := OpenRuntime(rt); err == nil {
+		t.Fatal("OpenRuntime succeeded unexpectedly without a reachable backend")
+	} else if !strings.Contains(err.Error(), "unsupported Wayland compositor") {
+		t.Fatalf("OpenRuntime error = %v, want unsupported-session error", err)
+	}
+}
+
 func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	rt := env.FromEnviron([]string{
 		"DISPLAY=:99",
@@ -23,5 +36,32 @@ func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	}
 	if _, ok := scr.(*X11Backend); !ok {
 		t.Fatalf("OpenRuntime type = %T, want *X11Backend", scr)
+	}
+}
+
+func TestProbeRuntime_NoSessionReportsBackends(t *testing.T) {
+	rt := env.FromEnviron([]string{})
+
+	got := ProbeRuntime(rt)
+	if len(got) != 5 {
+		t.Fatalf("ProbeRuntime len = %d, want 5", len(got))
+	}
+	wantNames := []string{
+		"kwin-shot2",
+		"wlr-screencopy",
+		"ext-image-copy-capture",
+		"gnome-shell-screenshot",
+		"portal",
+	}
+	for i, name := range wantNames {
+		if got[i].Name != name {
+			t.Fatalf("ProbeRuntime[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+		if got[i].Available || got[i].Selected {
+			t.Fatalf("ProbeRuntime[%d] available=%v selected=%v, want false/false", i, got[i].Available, got[i].Selected)
+		}
+		if got[i].Reason == "" {
+			t.Fatalf("ProbeRuntime[%d] missing reason", i)
+		}
 	}
 }

--- a/window/open_test.go
+++ b/window/open_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/nskaggs/perfuncted/internal/env"
 )
 
+func TestOpenRuntime_NoSessionReturnsError(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=" + t.TempDir(),
+	})
+
+	if _, err := OpenRuntime(rt); err == nil {
+		t.Fatal("OpenRuntime succeeded unexpectedly without a reachable backend")
+	} else if !strings.Contains(err.Error(), "unsupported Wayland compositor") {
+		t.Fatalf("OpenRuntime error = %v, want unsupported-session error", err)
+	}
+}
+
 func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	rt := env.FromEnviron([]string{
 		"DISPLAY=:99",
@@ -23,5 +36,26 @@ func TestOpenRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	}
 	if _, ok := mgr.(*X11Backend); !ok {
 		t.Fatalf("OpenRuntime type = %T, want *X11Backend", mgr)
+	}
+}
+
+func TestProbeRuntime_NoSessionReportsBackends(t *testing.T) {
+	rt := env.FromEnviron([]string{})
+
+	got := ProbeRuntime(rt)
+	if len(got) != 3 {
+		t.Fatalf("ProbeRuntime len = %d, want 3", len(got))
+	}
+	wantNames := []string{"kwin-scripting", "gnome-shell-eval", "foreign-toplevel"}
+	for i, name := range wantNames {
+		if got[i].Name != name {
+			t.Fatalf("ProbeRuntime[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+		if got[i].Available || got[i].Selected {
+			t.Fatalf("ProbeRuntime[%d] available=%v selected=%v, want false/false", i, got[i].Available, got[i].Selected)
+		}
+		if got[i].Reason == "" {
+			t.Fatalf("ProbeRuntime[%d] missing reason", i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add direct action-and-check coverage for OutputBundle.List and Perfuncted.Close
- Add live integration coverage for pf.Output.List in the shared session harness
- Cover empty-session selector error/probe paths for output, screen, and window

## Validation
- go test .
- go test ./output ./screen ./window
- go test -tags=integration ./integration -run '^TestOutputList_ReportsGeometry$' -count=1