### PR TITLE
Broaden input and bundle test coverage

### DIFF
--- a/bundle_input_test.go
+++ b/bundle_input_test.go
@@ -3,8 +3,8 @@ package perfuncted_test
 import (
 	"context"
 	"errors"
-	"image"
 	"fmt"
+	"image"
 	"testing"
 	"time"
 

--- a/bundle_input_test.go
+++ b/bundle_input_test.go
@@ -4,10 +4,51 @@ import (
 	"context"
 	"errors"
 	"image"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nskaggs/perfuncted/pftest"
+	"github.com/nskaggs/perfuncted/window"
 )
+
+type inputPointerSyncSpy struct {
+	pftest.Inputter
+	pointerCalls int
+	syncCalls    int
+}
+
+func (s *inputPointerSyncSpy) PointerLocation(context.Context) (int, int, error) {
+	s.pointerCalls++
+	return 42, 24, nil
+}
+
+func (s *inputPointerSyncSpy) Sync(context.Context) error {
+	s.syncCalls++
+	return nil
+}
+
+type windowSpyManager struct {
+	pftest.Manager
+	moveCalls  []string
+	closeCalls []string
+	syncCalls  int
+}
+
+func (m *windowSpyManager) Move(ctx context.Context, title string, x, y int) error {
+	m.moveCalls = append(m.moveCalls, fmt.Sprintf("%s:%d,%d", title, x, y))
+	return nil
+}
+
+func (m *windowSpyManager) CloseWindow(ctx context.Context, title string) error {
+	m.closeCalls = append(m.closeCalls, title)
+	return nil
+}
+
+func (m *windowSpyManager) Sync(ctx context.Context) error {
+	m.syncCalls++
+	return nil
+}
 
 func TestPerfunctedPaste_ClipboardPath(t *testing.T) {
 	inp := &pftest.Inputter{}
@@ -279,5 +320,96 @@ func TestInputBundleDragAndDropNilContext(t *testing.T) {
 	err := pf.Input.DragAndDrop(nil, 10, 20, 30, 40)
 	if !errors.Is(err, boom) {
 		t.Fatalf("DragAndDrop(nil) error = %v, want %v", err, boom)
+	}
+}
+
+func TestInputBundleMouseMoveDownUpPointerLocationAndSync(t *testing.T) {
+	spy := &inputPointerSyncSpy{}
+	pf := pftest.New(nil, spy, nil, nil)
+	ctx := context.Background()
+
+	if err := pf.Input.MouseMove(ctx, 10, 20); err != nil {
+		t.Fatalf("MouseMove: %v", err)
+	}
+	if err := pf.Input.MouseDown(ctx, 1); err != nil {
+		t.Fatalf("MouseDown: %v", err)
+	}
+	if err := pf.Input.MouseUp(ctx, 1); err != nil {
+		t.Fatalf("MouseUp: %v", err)
+	}
+	x, y, err := pf.Input.PointerLocation(ctx)
+	if err != nil {
+		t.Fatalf("PointerLocation: %v", err)
+	}
+	if err := pf.Input.Sync(ctx); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	wantCalls := []string{"move:10,20", "mousedown", "mouseup"}
+	if len(spy.Calls) != len(wantCalls) {
+		t.Fatalf("calls = %v, want %v", spy.Calls, wantCalls)
+	}
+	for i, want := range wantCalls {
+		if spy.Calls[i] != want {
+			t.Fatalf("call %d = %q, want %q", i, spy.Calls[i], want)
+		}
+	}
+	if x != 42 || y != 24 {
+		t.Fatalf("PointerLocation = (%d,%d), want (42,24)", x, y)
+	}
+	if spy.pointerCalls != 1 || spy.syncCalls != 1 {
+		t.Fatalf("pointerCalls=%d syncCalls=%d, want 1/1", spy.pointerCalls, spy.syncCalls)
+	}
+}
+
+func TestWindowBundleActiveTitleMoveCloseSyncAndWaiters(t *testing.T) {
+	mgr := &windowSpyManager{
+		Manager: pftest.Manager{
+			Titles: []string{"Firefox"},
+			Lists: [][]window.Info{
+				{{ID: 1, Title: "Firefox"}},
+				{},
+			},
+		},
+	}
+	pf := pftest.New(nil, nil, mgr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	title, err := pf.Window.ActiveTitle(ctx)
+	if err != nil {
+		t.Fatalf("ActiveTitle: %v", err)
+	}
+	if title != "Firefox" {
+		t.Fatalf("ActiveTitle = %q, want Firefox", title)
+	}
+	win, err := pf.Window.WaitForWindow(ctx, "Firefox", time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForWindow: %v", err)
+	}
+	if win.Title != "Firefox" {
+		t.Fatalf("WaitForWindow title = %q, want Firefox", win.Title)
+	}
+	if err := pf.Window.WaitForClose(ctx, "Firefox", time.Millisecond); err != nil {
+		t.Fatalf("WaitForClose: %v", err)
+	}
+	if err := pf.Window.Move(ctx, "Firefox", 10, 20); err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if err := pf.Window.CloseWindow(ctx, "Firefox"); err != nil {
+		t.Fatalf("CloseWindow: %v", err)
+	}
+	if err := pf.Window.Sync(ctx); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if len(mgr.moveCalls) != 1 || mgr.moveCalls[0] != "Firefox:10,20" {
+		t.Fatalf("moveCalls = %v, want [Firefox:10,20]", mgr.moveCalls)
+	}
+	if len(mgr.closeCalls) != 1 || mgr.closeCalls[0] != "Firefox" {
+		t.Fatalf("closeCalls = %v, want [Firefox]", mgr.closeCalls)
+	}
+	if mgr.syncCalls != 1 {
+		t.Fatalf("syncCalls = %d, want 1", mgr.syncCalls)
 	}
 }

--- a/input/open_runtime_fallback_test.go
+++ b/input/open_runtime_fallback_test.go
@@ -245,10 +245,10 @@ func TestOpenRuntimePrefersXTestOnX11(t *testing.T) {
 
 func TestCheckWlInputMethodWithGlobs(t *testing.T) {
 	tests := []struct {
-		name    string
-		globs   map[string]bool
-		want    bool
-		wantRe  string
+		name   string
+		globs  map[string]bool
+		want   bool
+		wantRe string
 	}{
 		{
 			name:   "nil",
@@ -290,10 +290,10 @@ func TestCheckWlInputMethodWithGlobs(t *testing.T) {
 
 func TestCheckWlVirtualWithGlobs(t *testing.T) {
 	tests := []struct {
-		name    string
-		globs   map[string]bool
-		want    bool
-		wantRe  string
+		name   string
+		globs  map[string]bool
+		want   bool
+		wantRe string
 	}{
 		{
 			name:   "nil",

--- a/input/open_runtime_fallback_test.go
+++ b/input/open_runtime_fallback_test.go
@@ -50,6 +50,7 @@ func TestOpenRuntimeFallsBackToXTestWhenWaylandSocketUnresolvable(t *testing.T) 
 		return nil, os.ErrNotExist
 	}
 
+	t.Setenv("PF_FORCE_INPUT", "")
 	rt := env.FromEnviron([]string{
 		"DISPLAY=:99",
 		"WAYLAND_DISPLAY=wayland-0",
@@ -90,6 +91,7 @@ func TestProbeRuntimeFallsBackToXTestWhenWaylandSocketUnresolvable(t *testing.T)
 		return nil, os.ErrNotExist
 	}
 
+	t.Setenv("PF_FORCE_INPUT", "")
 	rt := env.FromEnviron([]string{
 		"DISPLAY=:99",
 		"WAYLAND_DISPLAY=wayland-0",
@@ -105,5 +107,228 @@ func TestProbeRuntimeFallsBackToXTestWhenWaylandSocketUnresolvable(t *testing.T)
 	}
 	if !results[2].Available || !results[2].Selected {
 		t.Fatalf("ProbeRuntime xtest available=%v selected=%v, want true/true", results[2].Available, results[2].Selected)
+	}
+}
+
+func TestOpenUsesCurrentEnvironment(t *testing.T) {
+	oldWlInputMethod := newWlInputMethodBackend
+	oldWlVirtual := newWlVirtualBackend
+	oldXTest := newXTestBackend
+	oldUinput := newUinputBackend
+	t.Cleanup(func() {
+		newWlInputMethodBackend = oldWlInputMethod
+		newWlVirtualBackend = oldWlVirtual
+		newXTestBackend = oldXTest
+		newUinputBackend = oldUinput
+	})
+
+	var inputMethodCalls, virtualCalls, xTestCalls, uinputCalls int
+	newWlInputMethodBackend = func(string, int32, int32) (Inputter, error) {
+		inputMethodCalls++
+		return noopInputter{}, nil
+	}
+	newWlVirtualBackend = func(string) (Inputter, error) {
+		virtualCalls++
+		return nil, os.ErrNotExist
+	}
+	newXTestBackend = func(string) (Inputter, error) {
+		xTestCalls++
+		return nil, os.ErrNotExist
+	}
+	newUinputBackend = func(int32, int32) (Inputter, error) {
+		uinputCalls++
+		return nil, os.ErrNotExist
+	}
+
+	t.Setenv("PF_FORCE_INPUT", "")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("DISPLAY", ":99")
+
+	inp, err := Open(1024, 768)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, ok := inp.(noopInputter); !ok {
+		t.Fatalf("Open type = %T, want noopInputter", inp)
+	}
+	if inputMethodCalls != 1 || virtualCalls != 0 || xTestCalls != 0 || uinputCalls != 0 {
+		t.Fatalf("constructor calls = im:%d virtual:%d xtest:%d uinput:%d", inputMethodCalls, virtualCalls, xTestCalls, uinputCalls)
+	}
+}
+
+func TestProbeUsesCurrentEnvironment(t *testing.T) {
+	oldWlInputMethod := newWlInputMethodBackend
+	oldWlVirtual := newWlVirtualBackend
+	oldXTest := newXTestBackend
+	oldUinput := newUinputBackend
+	t.Cleanup(func() {
+		newWlInputMethodBackend = oldWlInputMethod
+		newWlVirtualBackend = oldWlVirtual
+		newXTestBackend = oldXTest
+		newUinputBackend = oldUinput
+	})
+
+	newWlInputMethodBackend = func(string, int32, int32) (Inputter, error) {
+		return nil, os.ErrNotExist
+	}
+	newWlVirtualBackend = func(string) (Inputter, error) {
+		return nil, os.ErrNotExist
+	}
+	newXTestBackend = func(string) (Inputter, error) {
+		return noopInputter{}, nil
+	}
+	newUinputBackend = func(int32, int32) (Inputter, error) {
+		return nil, os.ErrNotExist
+	}
+
+	t.Setenv("PF_FORCE_INPUT", "")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("DISPLAY", ":99")
+
+	results := Probe()
+	if len(results) < 3 {
+		t.Fatalf("Probe len = %d, want at least 3", len(results))
+	}
+	if results[2].Name != "xtest" {
+		t.Fatalf("Probe third result = %q, want xtest", results[2].Name)
+	}
+	if !results[2].Available || !results[2].Selected {
+		t.Fatalf("Probe xtest available=%v selected=%v, want true/true", results[2].Available, results[2].Selected)
+	}
+}
+
+func TestOpenRuntimePrefersXTestOnX11(t *testing.T) {
+	oldWlInputMethod := newWlInputMethodBackend
+	oldWlVirtual := newWlVirtualBackend
+	oldXTest := newXTestBackend
+	oldUinput := newUinputBackend
+	t.Cleanup(func() {
+		newWlInputMethodBackend = oldWlInputMethod
+		newWlVirtualBackend = oldWlVirtual
+		newXTestBackend = oldXTest
+		newUinputBackend = oldUinput
+	})
+
+	var inputMethodCalls, virtualCalls, xTestCalls, uinputCalls int
+	newWlInputMethodBackend = func(string, int32, int32) (Inputter, error) {
+		inputMethodCalls++
+		return nil, os.ErrNotExist
+	}
+	newWlVirtualBackend = func(string) (Inputter, error) {
+		virtualCalls++
+		return nil, os.ErrNotExist
+	}
+	newXTestBackend = func(string) (Inputter, error) {
+		xTestCalls++
+		return noopInputter{}, nil
+	}
+	newUinputBackend = func(int32, int32) (Inputter, error) {
+		uinputCalls++
+		return nil, os.ErrNotExist
+	}
+
+	t.Setenv("PF_FORCE_INPUT", "")
+	rt := env.FromEnviron([]string{"DISPLAY=:99"})
+	inp, err := OpenRuntime(rt, 1024, 768)
+	if err != nil {
+		t.Fatalf("OpenRuntime: %v", err)
+	}
+	if _, ok := inp.(noopInputter); !ok {
+		t.Fatalf("OpenRuntime type = %T, want noopInputter", inp)
+	}
+	if inputMethodCalls != 0 || virtualCalls != 0 || xTestCalls != 1 || uinputCalls != 0 {
+		t.Fatalf("constructor calls = im:%d virtual:%d xtest:%d uinput:%d", inputMethodCalls, virtualCalls, xTestCalls, uinputCalls)
+	}
+}
+
+func TestCheckWlInputMethodWithGlobs(t *testing.T) {
+	tests := []struct {
+		name    string
+		globs   map[string]bool
+		want    bool
+		wantRe  string
+	}{
+		{
+			name:   "nil",
+			globs:  nil,
+			want:   false,
+			wantRe: "connect wayland-0: failed",
+		},
+		{
+			name:   "missing manager",
+			globs:  map[string]bool{"wl_seat": true},
+			want:   false,
+			wantRe: "zwp_input_method_manager_v2 not advertised",
+		},
+		{
+			name:   "missing seat",
+			globs:  map[string]bool{"zwp_input_method_manager_v2": true},
+			want:   false,
+			wantRe: "wl_seat not advertised",
+		},
+		{
+			name:   "available",
+			globs:  map[string]bool{"zwp_input_method_manager_v2": true, "wl_seat": true},
+			want:   true,
+			wantRe: "zwp_input_method_manager_v2 + wl_seat available",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkWlInputMethodWithGlobs("wayland-0", tt.globs)
+			if r.Available != tt.want {
+				t.Fatalf("Available = %v, want %v", r.Available, tt.want)
+			}
+			if r.Reason != tt.wantRe {
+				t.Fatalf("Reason = %q, want %q", r.Reason, tt.wantRe)
+			}
+		})
+	}
+}
+
+func TestCheckWlVirtualWithGlobs(t *testing.T) {
+	tests := []struct {
+		name    string
+		globs   map[string]bool
+		want    bool
+		wantRe  string
+	}{
+		{
+			name:   "nil",
+			globs:  nil,
+			want:   false,
+			wantRe: "connect wayland-0: failed",
+		},
+		{
+			name:   "missing pointer manager",
+			globs:  map[string]bool{"zwp_virtual_keyboard_manager_v1": true, "wl_seat": true},
+			want:   false,
+			wantRe: "zwlr_virtual_pointer_manager_v1 not advertised",
+		},
+		{
+			name:   "missing keyboard manager",
+			globs:  map[string]bool{"zwlr_virtual_pointer_manager_v1": true, "wl_seat": true},
+			want:   false,
+			wantRe: "zwp_virtual_keyboard_manager_v1 not advertised",
+		},
+		{
+			name:   "available",
+			globs:  map[string]bool{"zwlr_virtual_pointer_manager_v1": true, "zwp_virtual_keyboard_manager_v1": true},
+			want:   true,
+			wantRe: "zwlr_virtual_pointer_manager_v1 + zwp_virtual_keyboard_manager_v1 available",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkWlVirtualWithGlobs("wayland-0", tt.globs)
+			if r.Available != tt.want {
+				t.Fatalf("Available = %v, want %v", r.Available, tt.want)
+			}
+			if r.Reason != tt.wantRe {
+				t.Fatalf("Reason = %q, want %q", r.Reason, tt.wantRe)
+			}
+		})
 	}
 }

--- a/input/uinput_test.go
+++ b/input/uinput_test.go
@@ -5,6 +5,7 @@ package input
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -12,7 +13,8 @@ import (
 )
 
 type recordingKeyboard struct {
-	events []string
+	events   []string
+	closeErr error
 }
 
 func (k *recordingKeyboard) KeyPress(key int) error {
@@ -32,9 +34,68 @@ func (k *recordingKeyboard) KeyUp(key int) error {
 
 func (k *recordingKeyboard) FetchSyspath() (string, error) { return "", nil }
 
-func (k *recordingKeyboard) Close() error { return nil }
+func (k *recordingKeyboard) Close() error { return k.closeErr }
 
 var _ uinput.Keyboard = (*recordingKeyboard)(nil)
+
+type recordingTouchPad struct {
+	events   []string
+	closeErr error
+}
+
+func (t *recordingTouchPad) record(s string) { t.events = append(t.events, s) }
+func (t *recordingTouchPad) MoveTo(x int32, y int32) error {
+	t.record(fmt.Sprintf("move:%d,%d", x, y))
+	return nil
+}
+func (t *recordingTouchPad) LeftClick() error  { t.record("left-click"); return nil }
+func (t *recordingTouchPad) RightClick() error { t.record("right-click"); return nil }
+func (t *recordingTouchPad) LeftPress() error  { t.record("left-press"); return nil }
+func (t *recordingTouchPad) LeftRelease() error {
+	t.record("left-release")
+	return nil
+}
+func (t *recordingTouchPad) RightPress() error { t.record("right-press"); return nil }
+func (t *recordingTouchPad) RightRelease() error {
+	t.record("right-release")
+	return nil
+}
+func (t *recordingTouchPad) TouchDown() error { t.record("touch-down"); return nil }
+func (t *recordingTouchPad) TouchUp() error   { t.record("touch-up"); return nil }
+func (t *recordingTouchPad) FetchSyspath() (string, error) { return "", nil }
+func (t *recordingTouchPad) Close() error                  { t.record("close"); return t.closeErr }
+
+var _ uinput.TouchPad = (*recordingTouchPad)(nil)
+
+type recordingMouse struct {
+	events   []string
+	closeErr error
+}
+
+func (m *recordingMouse) record(s string) { m.events = append(m.events, s) }
+func (m *recordingMouse) MoveLeft(pixel int32) error  { m.record(fmt.Sprintf("move-left:%d", pixel)); return nil }
+func (m *recordingMouse) MoveRight(pixel int32) error { m.record(fmt.Sprintf("move-right:%d", pixel)); return nil }
+func (m *recordingMouse) MoveUp(pixel int32) error    { m.record(fmt.Sprintf("move-up:%d", pixel)); return nil }
+func (m *recordingMouse) MoveDown(pixel int32) error  { m.record(fmt.Sprintf("move-down:%d", pixel)); return nil }
+func (m *recordingMouse) Move(x, y int32) error       { m.record(fmt.Sprintf("move:%d,%d", x, y)); return nil }
+func (m *recordingMouse) LeftClick() error            { m.record("left-click"); return nil }
+func (m *recordingMouse) RightClick() error           { m.record("right-click"); return nil }
+func (m *recordingMouse) MiddleClick() error          { m.record("middle-click"); return nil }
+func (m *recordingMouse) LeftPress() error            { m.record("left-press"); return nil }
+func (m *recordingMouse) LeftRelease() error          { m.record("left-release"); return nil }
+func (m *recordingMouse) RightPress() error           { m.record("right-press"); return nil }
+func (m *recordingMouse) RightRelease() error         { m.record("right-release"); return nil }
+func (m *recordingMouse) MiddlePress() error          { m.record("middle-press"); return nil }
+func (m *recordingMouse) MiddleRelease() error        { m.record("middle-release"); return nil }
+func (m *recordingMouse) Wheel(horizontal bool, delta int32) error {
+	m.record(fmt.Sprintf("wheel:%t:%d", horizontal, delta))
+	return nil
+}
+func (m *recordingMouse) FetchSyspath() (string, error) { return "", nil }
+func (m *recordingMouse) FetchSysPath() (string, error) { return "", nil }
+func (m *recordingMouse) Close() error                  { m.record("close"); return m.closeErr }
+
+var _ uinput.Mouse = (*recordingMouse)(nil)
 
 // newTestBackend creates a UinputBackend with a recording keyboard and the
 // QWERTY fallback rune map for tests that don't depend on kernel keymap probing.
@@ -47,11 +108,44 @@ func newTestBackend(t *testing.T) (*UinputBackend, *recordingKeyboard) {
 	}, kb
 }
 
+func newUinputActionBackend() (*UinputBackend, *recordingKeyboard, *recordingTouchPad, *recordingMouse) {
+	kb := &recordingKeyboard{}
+	tp := &recordingTouchPad{}
+	mouse := &recordingMouse{}
+	return &UinputBackend{
+		kb:         kb,
+		touchpad:   tp,
+		mouse:      mouse,
+		charToRune: qwertyRuneMap(),
+	}, kb, tp, mouse
+}
+
+func TestUinputKeyDownAndUp(t *testing.T) {
+	b, kb := newTestBackend(t)
+
+	if err := b.KeyDown(context.Background(), "a"); err != nil {
+		t.Fatalf("KeyDown: %v", err)
+	}
+	if err := b.KeyUp(context.Background(), "a"); err != nil {
+		t.Fatalf("KeyUp: %v", err)
+	}
+
+	want := []string{fmt.Sprintf("down:%d", uinput.KeyA), fmt.Sprintf("up:%d", uinput.KeyA)}
+	if len(kb.events) != len(want) {
+		t.Fatalf("events = %v, want %v", kb.events, want)
+	}
+	for i, exp := range want {
+		if kb.events[i] != exp {
+			t.Fatalf("event %d = %q, want %q", i, kb.events[i], exp)
+		}
+	}
+}
+
 func TestUinputTypeContextUppercaseUsesShift(t *testing.T) {
 	b, kb := newTestBackend(t)
 
-	if err := b.TypeContext(context.Background(), "A"); err != nil {
-		t.Fatalf("TypeContext: %v", err)
+	if err := b.Type(context.Background(), "A"); err != nil {
+		t.Fatalf("Type: %v", err)
 	}
 
 	want := []string{
@@ -174,6 +268,116 @@ func TestUinputTypeContextWithKeyCombo(t *testing.T) {
 		if kb.events[i] != event {
 			t.Fatalf("event %d = %q, want %q (all events: %v)", i, kb.events[i], event, kb.events)
 		}
+	}
+}
+
+func TestUinputMouseActionsAndScroll(t *testing.T) {
+	b, _, tp, mouse := newUinputActionBackend()
+
+	t.Run("MouseMove", func(t *testing.T) {
+		tp.events = nil
+		if err := b.MouseMove(context.Background(), 11, 22); err != nil {
+			t.Fatalf("MouseMove: %v", err)
+		}
+		want := []string{"move:11,22"}
+		if len(tp.events) != len(want) {
+			t.Fatalf("events = %v, want %v", tp.events, want)
+		}
+		for i, exp := range want {
+			if tp.events[i] != exp {
+				t.Fatalf("event %d = %q, want %q", i, tp.events[i], exp)
+			}
+		}
+	})
+
+	t.Run("MouseClick", func(t *testing.T) {
+		tp.events = nil
+		if err := b.MouseClick(context.Background(), 3, 4, 1); err != nil {
+			t.Fatalf("MouseClick: %v", err)
+		}
+		want := []string{"move:3,4", "left-press", "left-release"}
+		if len(tp.events) != len(want) {
+			t.Fatalf("events = %v, want %v", tp.events, want)
+		}
+		for i, exp := range want {
+			if tp.events[i] != exp {
+				t.Fatalf("event %d = %q, want %q", i, tp.events[i], exp)
+			}
+		}
+	})
+
+	t.Run("MouseButtons", func(t *testing.T) {
+		tp.events = nil
+		mouse.events = nil
+
+		if err := b.MouseDown(context.Background(), 1); err != nil {
+			t.Fatalf("MouseDown left: %v", err)
+		}
+		if err := b.MouseUp(context.Background(), 3); err != nil {
+			t.Fatalf("MouseUp right: %v", err)
+		}
+		if err := b.MouseDown(context.Background(), 2); err != nil {
+			t.Fatalf("MouseDown middle: %v", err)
+		}
+		if err := b.MouseUp(context.Background(), 2); err != nil {
+			t.Fatalf("MouseUp middle: %v", err)
+		}
+
+		if got := tp.events; len(got) != 2 || got[0] != "left-press" || got[1] != "right-release" {
+			t.Fatalf("touchpad events = %v, want [left-press right-release]", got)
+		}
+		if got := mouse.events; len(got) != 2 || got[0] != "middle-press" || got[1] != "middle-release" {
+			t.Fatalf("mouse events = %v, want [middle-press middle-release]", got)
+		}
+	})
+
+	t.Run("Scroll", func(t *testing.T) {
+		mouse.events = nil
+		if err := b.ScrollUp(context.Background(), 2); err != nil {
+			t.Fatalf("ScrollUp: %v", err)
+		}
+		if err := b.ScrollRight(context.Background(), 3); err != nil {
+			t.Fatalf("ScrollRight: %v", err)
+		}
+		if len(mouse.events) != 2 {
+			t.Fatalf("mouse events = %v, want 2 entries", mouse.events)
+		}
+		if mouse.events[0] != "wheel:false:-2" {
+			t.Fatalf("ScrollUp event = %q, want wheel:false:-2", mouse.events[0])
+		}
+		if mouse.events[1] != "wheel:true:3" {
+			t.Fatalf("ScrollRight event = %q, want wheel:true:3", mouse.events[1])
+		}
+	})
+}
+
+func TestUinputPointerLocationUnsupported(t *testing.T) {
+	b, _ := newTestBackend(t)
+	if _, _, err := b.PointerLocation(context.Background()); err == nil {
+		t.Fatal("PointerLocation succeeded unexpectedly")
+	}
+}
+
+func TestUinputCloseClosesAllDevices(t *testing.T) {
+	kb := &recordingKeyboard{closeErr: errors.New("keyboard close failed")}
+	tp := &recordingTouchPad{closeErr: errors.New("touchpad close failed")}
+	mouse := &recordingMouse{closeErr: errors.New("mouse close failed")}
+	b := &UinputBackend{
+		kb:         kb,
+		touchpad:   tp,
+		mouse:      mouse,
+		charToRune: qwertyRuneMap(),
+	}
+
+	err := b.Close()
+	if !errors.Is(err, kb.closeErr) || !errors.Is(err, tp.closeErr) || !errors.Is(err, mouse.closeErr) {
+		t.Fatalf("Close error = %v, want joined close errors", err)
+	}
+	if len(kb.events) != 0 || len(tp.events) != 1 || len(mouse.events) != 1 {
+		t.Fatalf("close events = kb:%v tp:%v mouse:%v", kb.events, tp.events, mouse.events)
+	}
+	if tp.events[0] != "close" || mouse.events[0] != "close" {
+		t.Fatalf("close events = tp:%v mouse:%v, want close entries", tp.events, mouse.events)
 	}
 }
 

--- a/input/uinput_test.go
+++ b/input/uinput_test.go
@@ -60,8 +60,8 @@ func (t *recordingTouchPad) RightRelease() error {
 	t.record("right-release")
 	return nil
 }
-func (t *recordingTouchPad) TouchDown() error { t.record("touch-down"); return nil }
-func (t *recordingTouchPad) TouchUp() error   { t.record("touch-up"); return nil }
+func (t *recordingTouchPad) TouchDown() error              { t.record("touch-down"); return nil }
+func (t *recordingTouchPad) TouchUp() error                { t.record("touch-up"); return nil }
 func (t *recordingTouchPad) FetchSyspath() (string, error) { return "", nil }
 func (t *recordingTouchPad) Close() error                  { t.record("close"); return t.closeErr }
 
@@ -73,20 +73,35 @@ type recordingMouse struct {
 }
 
 func (m *recordingMouse) record(s string) { m.events = append(m.events, s) }
-func (m *recordingMouse) MoveLeft(pixel int32) error  { m.record(fmt.Sprintf("move-left:%d", pixel)); return nil }
-func (m *recordingMouse) MoveRight(pixel int32) error { m.record(fmt.Sprintf("move-right:%d", pixel)); return nil }
-func (m *recordingMouse) MoveUp(pixel int32) error    { m.record(fmt.Sprintf("move-up:%d", pixel)); return nil }
-func (m *recordingMouse) MoveDown(pixel int32) error  { m.record(fmt.Sprintf("move-down:%d", pixel)); return nil }
-func (m *recordingMouse) Move(x, y int32) error       { m.record(fmt.Sprintf("move:%d,%d", x, y)); return nil }
-func (m *recordingMouse) LeftClick() error            { m.record("left-click"); return nil }
-func (m *recordingMouse) RightClick() error           { m.record("right-click"); return nil }
-func (m *recordingMouse) MiddleClick() error          { m.record("middle-click"); return nil }
-func (m *recordingMouse) LeftPress() error            { m.record("left-press"); return nil }
-func (m *recordingMouse) LeftRelease() error          { m.record("left-release"); return nil }
-func (m *recordingMouse) RightPress() error           { m.record("right-press"); return nil }
-func (m *recordingMouse) RightRelease() error         { m.record("right-release"); return nil }
-func (m *recordingMouse) MiddlePress() error          { m.record("middle-press"); return nil }
-func (m *recordingMouse) MiddleRelease() error        { m.record("middle-release"); return nil }
+func (m *recordingMouse) MoveLeft(pixel int32) error {
+	m.record(fmt.Sprintf("move-left:%d", pixel))
+	return nil
+}
+func (m *recordingMouse) MoveRight(pixel int32) error {
+	m.record(fmt.Sprintf("move-right:%d", pixel))
+	return nil
+}
+func (m *recordingMouse) MoveUp(pixel int32) error {
+	m.record(fmt.Sprintf("move-up:%d", pixel))
+	return nil
+}
+func (m *recordingMouse) MoveDown(pixel int32) error {
+	m.record(fmt.Sprintf("move-down:%d", pixel))
+	return nil
+}
+func (m *recordingMouse) Move(x, y int32) error {
+	m.record(fmt.Sprintf("move:%d,%d", x, y))
+	return nil
+}
+func (m *recordingMouse) LeftClick() error     { m.record("left-click"); return nil }
+func (m *recordingMouse) RightClick() error    { m.record("right-click"); return nil }
+func (m *recordingMouse) MiddleClick() error   { m.record("middle-click"); return nil }
+func (m *recordingMouse) LeftPress() error     { m.record("left-press"); return nil }
+func (m *recordingMouse) LeftRelease() error   { m.record("left-release"); return nil }
+func (m *recordingMouse) RightPress() error    { m.record("right-press"); return nil }
+func (m *recordingMouse) RightRelease() error  { m.record("right-release"); return nil }
+func (m *recordingMouse) MiddlePress() error   { m.record("middle-press"); return nil }
+func (m *recordingMouse) MiddleRelease() error { m.record("middle-release"); return nil }
 func (m *recordingMouse) Wheel(horizontal bool, delta int32) error {
 	m.record(fmt.Sprintf("wheel:%t:%d", horizontal, delta))
 	return nil

--- a/input/wl_input_method_test.go
+++ b/input/wl_input_method_test.go
@@ -6,6 +6,7 @@ package input
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/nskaggs/perfuncted/internal/wl"
@@ -112,12 +113,148 @@ func TestWlInputMethodBackend_New_Unreachable(t *testing.T) {
 	t.Logf("got expected error: %v", err)
 }
 
-func TestWlInputMethodBackend_Delegate_NoOther(t *testing.T) {
-	// We can't easily construct a WlInputMethodBackend without a real connection,
-	// but we can verify the delegation pattern by checking that methods return
-	// errors when other is nil.
-	// This requires a real Wayland connection, so we just verify the error path.
-	t.Log("Delegation test requires real Wayland connection; skipping full test")
+type recordingOtherInputter struct {
+	Calls    []string
+	closed   bool
+	closeErr error
+}
+
+func (r *recordingOtherInputter) record(s string) { r.Calls = append(r.Calls, s) }
+func (r *recordingOtherInputter) KeyDown(ctx context.Context, key string) error {
+	r.record("down:" + key)
+	return nil
+}
+func (r *recordingOtherInputter) KeyUp(ctx context.Context, key string) error {
+	r.record("up:" + key)
+	return nil
+}
+func (r *recordingOtherInputter) Type(ctx context.Context, s string) error {
+	r.record("type:" + s)
+	return nil
+}
+func (r *recordingOtherInputter) MouseMove(ctx context.Context, x, y int) error {
+	r.record("move")
+	return nil
+}
+func (r *recordingOtherInputter) MouseClick(ctx context.Context, x, y, button int) error {
+	r.record("click")
+	return nil
+}
+func (r *recordingOtherInputter) MouseDown(ctx context.Context, button int) error {
+	r.record("mousedown")
+	return nil
+}
+func (r *recordingOtherInputter) MouseUp(ctx context.Context, button int) error {
+	r.record("mouseup")
+	return nil
+}
+func (r *recordingOtherInputter) ScrollUp(ctx context.Context, clicks int) error {
+	r.record("scroll-up")
+	return nil
+}
+func (r *recordingOtherInputter) ScrollDown(ctx context.Context, clicks int) error {
+	r.record("scroll-down")
+	return nil
+}
+func (r *recordingOtherInputter) ScrollLeft(ctx context.Context, clicks int) error {
+	r.record("scroll-left")
+	return nil
+}
+func (r *recordingOtherInputter) ScrollRight(ctx context.Context, clicks int) error {
+	r.record("scroll-right")
+	return nil
+}
+func (r *recordingOtherInputter) PointerLocation(ctx context.Context) (int, int, error) {
+	r.record("pointer")
+	return 42, 24, nil
+}
+func (r *recordingOtherInputter) Sync(ctx context.Context) error {
+	r.record("sync")
+	return nil
+}
+func (r *recordingOtherInputter) Close() error {
+	r.closed = true
+	r.record("close")
+	return r.closeErr
+}
+
+func TestWlInputMethodBackend_NoOtherReturnsUnsupported(t *testing.T) {
+	b := &WlInputMethodBackend{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "Type", run: func() error { return b.Type(ctx, "text") }},
+		{name: "KeyDown", run: func() error { return b.KeyDown(ctx, "a") }},
+		{name: "MouseMove", run: func() error { return b.MouseMove(ctx, 1, 2) }},
+		{name: "ScrollUp", run: func() error { return b.ScrollUp(ctx, 1) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil {
+				t.Fatalf("%s succeeded unexpectedly", tt.name)
+			}
+		})
+	}
+	x, y, err := b.PointerLocation(ctx)
+	if err == nil {
+		t.Fatal("PointerLocation succeeded unexpectedly")
+	}
+	if x != 0 || y != 0 {
+		t.Fatalf("PointerLocation = (%d,%d), want zeros", x, y)
+	}
+	if err := b.Sync(ctx); err != nil {
+		t.Fatalf("Sync without other backend = %v, want nil", err)
+	}
+}
+
+func TestWlInputMethodBackend_DelegatesToOther(t *testing.T) {
+	other := &recordingOtherInputter{}
+	b := &WlInputMethodBackend{other: other}
+	ctx := context.Background()
+
+	if err := b.Type(ctx, "hello"); err != nil {
+		t.Fatalf("Type: %v", err)
+	}
+	if err := b.KeyDown(ctx, "a"); err != nil {
+		t.Fatalf("KeyDown: %v", err)
+	}
+	if err := b.MouseMove(ctx, 10, 20); err != nil {
+		t.Fatalf("MouseMove: %v", err)
+	}
+	if err := b.ScrollRight(ctx, 3); err != nil {
+		t.Fatalf("ScrollRight: %v", err)
+	}
+	if err := b.Sync(ctx); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	want := []string{"type:hello", "down:a", "move", "scroll-right", "sync"}
+	if len(other.Calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", other.Calls, want)
+	}
+	for i, exp := range want {
+		if other.Calls[i] != exp {
+			t.Fatalf("call %d = %q, want %q", i, other.Calls[i], exp)
+		}
+	}
+}
+
+func TestWlInputMethodBackend_CloseClosesOther(t *testing.T) {
+	closeErr := errors.New("other close failed")
+	other := &recordingOtherInputter{closeErr: closeErr}
+	b := &WlInputMethodBackend{other: other}
+
+	err := b.Close()
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("Close error = %v, want %v", err, closeErr)
+	}
+	if !other.closed {
+		t.Fatal("Close did not close subordinate backend")
+	}
 }
 
 func TestWlInputMethodBackend_CanceledContextShortCircuitsNoOther(t *testing.T) {

--- a/input/wl_virtual_test.go
+++ b/input/wl_virtual_test.go
@@ -4,8 +4,15 @@
 package input
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nskaggs/perfuncted/internal/wl"
 )
@@ -85,6 +92,202 @@ func TestScroll_SignConvention(t *testing.T) {
 	downValue := int32(3 * 15 * 256)
 	if downValue != 11520 {
 		t.Errorf("3 notches down = %d, want 11520", downValue)
+	}
+}
+
+func newCapturedWlVirtualBackend(t *testing.T) (*WlVirtualBackend, *net.UnixConn) {
+	t.Helper()
+	sock := filepath.Join(os.TempDir(), fmt.Sprintf("pf-wl-%d.sock", time.Now().UnixNano()))
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+
+	accepted := make(chan *net.UnixConn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	ctx, err := wl.Connect(sock)
+	if err != nil {
+		_ = listener.Close()
+		t.Fatalf("Connect: %v", err)
+	}
+
+	var serverConn *net.UnixConn
+	select {
+	case serverConn = <-accepted:
+	case err := <-acceptErr:
+		_ = listener.Close()
+		_ = ctx.Close()
+		t.Fatalf("AcceptUnix: %v", err)
+	case <-time.After(time.Second):
+		_ = listener.Close()
+		_ = ctx.Close()
+		t.Fatal("AcceptUnix timed out")
+	}
+
+	b := &WlVirtualBackend{
+		display: wl.NewDisplay(ctx),
+		ptr:     &wl.RawProxy{},
+		outW:    1920,
+		outH:    1080,
+	}
+	b.ptr.SetID(7)
+
+	t.Cleanup(func() {
+		_ = ctx.Close()
+		_ = serverConn.Close()
+		_ = listener.Close()
+		_ = os.Remove(sock)
+	})
+
+	return b, serverConn
+}
+
+func readCapturedWlWrites(t *testing.T, conn *net.UnixConn) [][]byte {
+	t.Helper()
+	var buf bytes.Buffer
+	scratch := make([]byte, 4096)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		n, err := conn.Read(scratch)
+		if n > 0 {
+			buf.Write(scratch[:n])
+			continue
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				break
+			}
+			t.Fatalf("read captured writes: %v", err)
+		} else {
+			break
+		}
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	data := buf.Bytes()
+	var msgs [][]byte
+	for len(data) > 0 {
+		if len(data) < 8 {
+			t.Fatalf("captured truncated message: %d bytes", len(data))
+		}
+		size := int(wl.Uint32(data[4:8]) >> 16)
+		if size < 8 || size > len(data) {
+			t.Fatalf("invalid Wayland message size %d (remaining=%d)", size, len(data))
+		}
+		msgs = append(msgs, append([]byte(nil), data[:size]...))
+		data = data[size:]
+	}
+	return msgs
+}
+
+func TestWlVirtualBackend_MouseMoveWritesMotionAndFrame(t *testing.T) {
+	b, conn := newCapturedWlVirtualBackend(t)
+
+	if err := b.MouseMove(context.Background(), 123, 456); err != nil {
+		t.Fatalf("MouseMove: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	msgs := readCapturedWlWrites(t, conn)
+	if len(msgs) != 2 {
+		t.Fatalf("writes = %d, want 2", len(msgs))
+	}
+	first := msgs[0]
+	if got := wl.Uint32(first[0:4]); got != 7 {
+		t.Fatalf("sender id = %d, want 7", got)
+	}
+	if got := wl.Uint32(first[4:8]) & 0xffff; got != 1 {
+		t.Fatalf("opcode = %d, want motion_absolute", got)
+	}
+	if got := wl.Uint32(first[12:16]); got != 123 || wl.Uint32(first[16:20]) != 456 {
+		t.Fatalf("motion coords = (%d,%d), want (123,456)", wl.Uint32(first[12:16]), wl.Uint32(first[16:20]))
+	}
+	if got := wl.Uint32(first[20:24]); got != 1920 || wl.Uint32(first[24:28]) != 1080 {
+		t.Fatalf("motion size = (%d,%d), want (1920,1080)", wl.Uint32(first[20:24]), wl.Uint32(first[24:28]))
+	}
+	second := msgs[1]
+	if got := wl.Uint32(second[4:8]) & 0xffff; got != 4 {
+		t.Fatalf("frame opcode = %d, want 4", got)
+	}
+}
+
+func TestWlVirtualBackend_MouseClickWritesSequence(t *testing.T) {
+	b, conn := newCapturedWlVirtualBackend(t)
+
+	if err := b.MouseClick(context.Background(), 10, 20, 1); err != nil {
+		t.Fatalf("MouseClick: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	msgs := readCapturedWlWrites(t, conn)
+	if len(msgs) != 6 {
+		t.Fatalf("writes = %d, want 6", len(msgs))
+	}
+	if got := wl.Uint32(msgs[0][4:8]) & 0xffff; got != 1 {
+		t.Fatalf("first opcode = %d, want motion_absolute", got)
+	}
+	if got := wl.Uint32(msgs[2][4:8]) & 0xffff; got != 2 {
+		t.Fatalf("third opcode = %d, want button", got)
+	}
+	if got := wl.Uint32(msgs[4][4:8]) & 0xffff; got != 2 {
+		t.Fatalf("fifth opcode = %d, want button release", got)
+	}
+}
+
+func TestWlVirtualBackend_ScrollWritesAxis(t *testing.T) {
+	b, conn := newCapturedWlVirtualBackend(t)
+
+	if err := b.ScrollRight(context.Background(), 2); err != nil {
+		t.Fatalf("ScrollRight: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	msgs := readCapturedWlWrites(t, conn)
+	if len(msgs) != 2 {
+		t.Fatalf("writes = %d, want 2", len(msgs))
+	}
+	first := msgs[0]
+	if got := wl.Uint32(first[4:8]) & 0xffff; got != 3 {
+		t.Fatalf("opcode = %d, want axis", got)
+	}
+	if got := int32(wl.Uint32(first[16:20])); got != 2*15*256 {
+		t.Fatalf("scroll value = %d, want %d", got, 2*15*256)
+	}
+	second := msgs[1]
+	if got := wl.Uint32(second[4:8]) & 0xffff; got != 4 {
+		t.Fatalf("frame opcode = %d, want 4", got)
+	}
+}
+
+func TestWlVirtualBackend_PointerLocationUnsupported(t *testing.T) {
+	b := &WlVirtualBackend{}
+	if _, _, err := b.PointerLocation(context.Background()); err == nil {
+		t.Fatal("PointerLocation succeeded unexpectedly")
+	}
+}
+
+func TestWlVirtualBackend_CloseUsesDisplayContextWhenSessionMissing(t *testing.T) {
+	b, conn := newCapturedWlVirtualBackend(t)
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	msgs := readCapturedWlWrites(t, conn)
+	if len(msgs) != 0 {
+		t.Fatalf("close captured %d writes, want 0", len(msgs))
 	}
 }
 

--- a/input/xtest_test.go
+++ b/input/xtest_test.go
@@ -31,6 +31,20 @@ func newXTestMock(t *testing.T, keysyms []xproto.Keysym) (*XTestBackend, *x11.Mo
 	return b, mc
 }
 
+type closeSpyX11Connection struct {
+	x11.MockConnection
+	closed bool
+	synced bool
+}
+
+func (c *closeSpyX11Connection) Close() {
+	c.closed = true
+}
+
+func (c *closeSpyX11Connection) Sync() {
+	c.synced = true
+}
+
 func TestKeyDownMapsToFakeInput(t *testing.T) {
 	b, mc := newXTestMock(t, []xproto.Keysym{0x61}) // 'a'
 	if err := b.KeyDown(context.Background(), "a"); err != nil {
@@ -72,6 +86,157 @@ func TestMouseMoveUsesMotionNotify(t *testing.T) {
 	}
 }
 
+func TestMouseClickUsesMotionPressRelease(t *testing.T) {
+	b, mc := newXTestMock(t, nil)
+	b.delay = 0
+
+	var events []struct {
+		eventType byte
+		detail    byte
+	}
+	mc.FakeInputCheckedFunc = func(eventType, detail byte, _ uint32, _ xproto.Window, _, _ int16, _ byte) x11.XTestFakeInputCookie {
+		events = append(events, struct {
+			eventType byte
+			detail    byte
+		}{eventType: eventType, detail: detail})
+		return x11.NewMockXTestFakeInputCookie(nil)
+	}
+
+	if err := b.MouseClick(context.Background(), 11, 22, 1); err != nil {
+		t.Fatalf("MouseClick: %v", err)
+	}
+
+	want := []struct {
+		eventType byte
+		detail    byte
+	}{
+		{eventType: xproto.MotionNotify, detail: 0},
+		{eventType: xproto.ButtonPress, detail: 1},
+		{eventType: xproto.ButtonRelease, detail: 1},
+	}
+	if len(events) != len(want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+	for i, exp := range want {
+		if events[i] != exp {
+			t.Fatalf("event %d = %+v, want %+v", i, events[i], exp)
+		}
+	}
+}
+
+func TestScrollMethodsUseExpectedButtons(t *testing.T) {
+	b, mc := newXTestMock(t, nil)
+	var events []struct {
+		eventType byte
+		detail    byte
+	}
+	mc.FakeInputCheckedFunc = func(eventType, detail byte, _ uint32, _ xproto.Window, _, _ int16, _ byte) x11.XTestFakeInputCookie {
+		events = append(events, struct {
+			eventType byte
+			detail    byte
+		}{eventType: eventType, detail: detail})
+		return x11.NewMockXTestFakeInputCookie(nil)
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+		want byte
+	}{
+		{name: "ScrollUp", run: func() error { return b.ScrollUp(context.Background(), 1) }, want: 4},
+		{name: "ScrollDown", run: func() error { return b.ScrollDown(context.Background(), 1) }, want: 5},
+		{name: "ScrollLeft", run: func() error { return b.ScrollLeft(context.Background(), 1) }, want: 6},
+		{name: "ScrollRight", run: func() error { return b.ScrollRight(context.Background(), 1) }, want: 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events = events[:0]
+			if err := tt.run(); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+			want := []struct {
+				eventType byte
+				detail    byte
+			}{
+				{eventType: xproto.ButtonPress, detail: tt.want},
+				{eventType: xproto.ButtonRelease, detail: tt.want},
+			}
+			if len(events) != len(want) {
+				t.Fatalf("events = %v, want %v", events, want)
+			}
+			for i, exp := range want {
+				if events[i] != exp {
+					t.Fatalf("event %d = %+v, want %+v", i, events[i], exp)
+				}
+			}
+		})
+	}
+}
+
+func TestPointerLocationReportsCurrentPosition(t *testing.T) {
+	b, mc := newXTestMock(t, nil)
+	mc.QueryPointerFunc = func(xproto.Window) x11.QueryPointerCookie {
+		return x11.NewMockQueryPointerCookie(&xproto.QueryPointerReply{
+			RootX: 321,
+			RootY: 654,
+		})
+	}
+
+	x, y, err := b.PointerLocation(context.Background())
+	if err != nil {
+		t.Fatalf("PointerLocation: %v", err)
+	}
+	if x != 321 || y != 654 {
+		t.Fatalf("PointerLocation = (%d,%d), want (321,654)", x, y)
+	}
+}
+
+func TestXTestBackend_CloseInvokesConnectionClose(t *testing.T) {
+	spy := &closeSpyX11Connection{}
+	spy.DefaultScreenFunc = func() *xproto.ScreenInfo { return &xproto.ScreenInfo{Root: xproto.Window(1)} }
+	spy.SetupFunc = func() *xproto.SetupInfo { return &xproto.SetupInfo{MinKeycode: 8, MaxKeycode: 8} }
+	spy.GetKeyboardMappingFunc = func(_ xproto.Keycode, _ byte) x11.GetKeyboardMappingCookie {
+		return x11.NewMockGetKeyboardMappingCookie(&xproto.GetKeyboardMappingReply{
+			KeysymsPerKeycode: 1,
+			Keysyms:           []xproto.Keysym{0x61},
+		})
+	}
+
+	b, err := NewXTestBackendWithConn(spy)
+	if err != nil {
+		t.Fatalf("NewXTestBackendWithConn: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !spy.closed {
+		t.Fatal("Close did not close underlying connection")
+	}
+}
+
+func TestXTestBackend_SyncInvokesConnectionSync(t *testing.T) {
+	spy := &closeSpyX11Connection{}
+	spy.DefaultScreenFunc = func() *xproto.ScreenInfo { return &xproto.ScreenInfo{Root: xproto.Window(1)} }
+	spy.SetupFunc = func() *xproto.SetupInfo { return &xproto.SetupInfo{MinKeycode: 8, MaxKeycode: 8} }
+	spy.GetKeyboardMappingFunc = func(_ xproto.Keycode, _ byte) x11.GetKeyboardMappingCookie {
+		return x11.NewMockGetKeyboardMappingCookie(&xproto.GetKeyboardMappingReply{
+			KeysymsPerKeycode: 1,
+			Keysyms:           []xproto.Keysym{0x61},
+		})
+	}
+
+	b, err := NewXTestBackendWithConn(spy)
+	if err != nil {
+		t.Fatalf("NewXTestBackendWithConn: %v", err)
+	}
+	if err := b.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if !spy.synced {
+		t.Fatal("Sync did not call underlying connection Sync")
+	}
+}
+
 func TestTypeCtrlA(t *testing.T) {
 	// Map ctrl (0xffe3=65507) and 'a' (0x61=97) each to separate keycodes.
 	mc := &x11.MockConnection{}
@@ -96,8 +261,8 @@ func TestTypeCtrlA(t *testing.T) {
 	}
 
 	// Type("{ctrl+a}") should press Ctrl, tap A, release Ctrl = 4 events
-	if err := b.TypeContext(context.Background(), "{ctrl+a}"); err != nil {
-		t.Fatalf("TypeContext: %v", err)
+	if err := b.Type(context.Background(), "{ctrl+a}"); err != nil {
+		t.Fatalf("Type: %v", err)
 	}
 	if len(events) != 4 {
 		t.Fatalf("expected 4 events, got %d: %v", len(events), events)


### PR DESCRIPTION
Adds action-and-check coverage for input runtime selection and XTest/UInput/Wayland input backends, plus root-level bundle coverage for input and window behavior. Validation: go test ./..., go test -tags=integration ./integration -run '^TestIntegration$' -count=1.