### PR TITLE
Cover screen clipboard and output paths

### DIFF
--- a/output/wayland_test.go
+++ b/output/wayland_test.go
@@ -15,6 +15,10 @@ func wlStringData(s string) []byte {
 	return out
 }
 
+func appendWlStringData(dst []byte, s string) []byte {
+	return append(dst, wlStringData(s)...)
+}
+
 func TestReadWlString(t *testing.T) {
 	t.Parallel()
 
@@ -84,5 +88,95 @@ func TestReadWlStringRejectsMalformedData(t *testing.T) {
 				t.Fatalf("readWlString(%v) = %q, next=%d, ok=true; want ok=false", tt.data, got, next)
 			}
 		})
+	}
+}
+
+func TestWaylandOutputEventParsing(t *testing.T) {
+	t.Parallel()
+
+	out := &waylandOutput{
+		info: Info{Name: "fallback-name", Backend: "wayland", Scale: 1},
+	}
+	proxy := &wl.RawProxy{}
+	out.updateProxy(proxy)
+
+	geometry := make([]byte, 20)
+	wl.PutUint32(geometry[0:4], ^uint32(9))
+	wl.PutUint32(geometry[4:8], 20)
+	wl.PutUint32(geometry[8:12], 600)
+	wl.PutUint32(geometry[12:16], 340)
+	geometry = appendWlStringData(geometry, "Acme")
+	geometry = appendWlStringData(geometry, "Panel 4K")
+	proxy.OnEvent(0, 0, geometry)
+
+	mode := make([]byte, 16)
+	wl.PutUint32(mode[0:4], 1)
+	wl.PutUint32(mode[4:8], 3840)
+	wl.PutUint32(mode[8:12], 2160)
+	proxy.OnEvent(1, 0, mode)
+
+	scale := make([]byte, 4)
+	wl.PutUint32(scale, 2)
+	proxy.OnEvent(3, 0, scale)
+
+	proxy.OnEvent(4, 0, wlStringData("DP-1"))
+	proxy.OnEvent(5, 0, wlStringData("Acme Panel 4K"))
+
+	if out.info.Geometry.X != -10 || out.info.Geometry.Y != 20 {
+		t.Fatalf("geometry origin = %+v, want -10,20", out.info.Geometry)
+	}
+	if out.info.PhysicalW != 600 || out.info.PhysicalH != 340 {
+		t.Fatalf("physical size = %dx%d, want 600x340", out.info.PhysicalW, out.info.PhysicalH)
+	}
+	if out.info.Make != "Acme" || out.info.Model != "Panel 4K" {
+		t.Fatalf("make/model = %q/%q, want Acme/Panel 4K", out.info.Make, out.info.Model)
+	}
+	if out.info.ResolutionW != 3840 || out.info.ResolutionH != 2160 {
+		t.Fatalf("resolution = %dx%d, want 3840x2160", out.info.ResolutionW, out.info.ResolutionH)
+	}
+	if out.info.Scale != 2 {
+		t.Fatalf("scale = %d, want 2", out.info.Scale)
+	}
+	if out.info.Geometry.W != 1920 || out.info.Geometry.H != 1080 {
+		t.Fatalf("geometry size = %dx%d, want 1920x1080", out.info.Geometry.W, out.info.Geometry.H)
+	}
+	if out.info.Name != "DP-1" {
+		t.Fatalf("name = %q, want DP-1", out.info.Name)
+	}
+	if out.info.Description != "Acme Panel 4K" {
+		t.Fatalf("description = %q, want Acme Panel 4K", out.info.Description)
+	}
+}
+
+func TestWaylandOutputEventParsingIgnoresMalformedEvents(t *testing.T) {
+	t.Parallel()
+
+	out := &waylandOutput{
+		info: Info{
+			Name:        "before",
+			Description: "description before",
+			Geometry:    Geometry{X: 1, Y: 2, W: 3, H: 4},
+			ResolutionW: 3,
+			ResolutionH: 4,
+			Scale:       1,
+		},
+	}
+	proxy := &wl.RawProxy{}
+	out.updateProxy(proxy)
+
+	proxy.OnEvent(0, 0, []byte{1, 2, 3})
+	proxy.OnEvent(1, 0, []byte{1, 2, 3})
+	proxy.OnEvent(3, 0, []byte{1, 2, 3})
+	proxy.OnEvent(4, 0, []byte{1, 2, 3})
+	proxy.OnEvent(5, 0, []byte{1, 2, 3})
+
+	if out.info.Name != "before" {
+		t.Fatalf("name changed to %q after malformed event", out.info.Name)
+	}
+	if out.info.Description != "description before" {
+		t.Fatalf("description changed to %q after malformed event", out.info.Description)
+	}
+	if out.info.Geometry != (Geometry{X: 1, Y: 2, W: 3, H: 4}) {
+		t.Fatalf("geometry changed to %+v after malformed event", out.info.Geometry)
 	}
 }

--- a/perfuncted_clipboard_test.go
+++ b/perfuncted_clipboard_test.go
@@ -2,10 +2,41 @@ package perfuncted_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/nskaggs/perfuncted"
 	"github.com/nskaggs/perfuncted/pftest"
 )
+
+type clipboardSpy struct {
+	text       string
+	getCalls   int
+	setCalls   int
+	closeCalls int
+	ctxValue   any
+	getErr     error
+	setErr     error
+	closeErr   error
+}
+
+func (c *clipboardSpy) Get(ctx context.Context) (string, error) {
+	c.getCalls++
+	c.ctxValue = ctx.Value(contextKey{})
+	return c.text, c.getErr
+}
+
+func (c *clipboardSpy) Set(ctx context.Context, text string) error {
+	c.setCalls++
+	c.ctxValue = ctx.Value(contextKey{})
+	c.text = text
+	return c.setErr
+}
+
+func (c *clipboardSpy) Close() error {
+	c.closeCalls++
+	return c.closeErr
+}
 
 func TestClipboardBundle(t *testing.T) {
 	sc := &pftest.Screenshotter{Width: 1024, Height: 768}
@@ -45,5 +76,54 @@ func TestPerfunctedPaste(t *testing.T) {
 		if inp.Calls[i] != want[i] {
 			t.Errorf("call[%d] = %q; want %q", i, inp.Calls[i], want[i])
 		}
+	}
+}
+
+func TestClipboardBundleContextErrorsAndClose(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKey{}, "clipboard-token")
+	closeErr := errors.New("clipboard close failed")
+	cb := &clipboardSpy{closeErr: closeErr}
+	pf := &perfuncted.Perfuncted{
+		Clipboard: perfuncted.ClipboardBundle{Clipboard: cb},
+	}
+
+	if err := pf.Clipboard.Set(ctx, "hello"); err != nil {
+		t.Fatalf("Clipboard.Set: %v", err)
+	}
+	if cb.setCalls != 1 {
+		t.Fatalf("Set calls = %d, want 1", cb.setCalls)
+	}
+	if cb.ctxValue != "clipboard-token" {
+		t.Fatalf("Set context value = %v, want clipboard-token", cb.ctxValue)
+	}
+
+	got, err := pf.Clipboard.Get(ctx)
+	if err != nil {
+		t.Fatalf("Clipboard.Get: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("Clipboard.Get = %q, want %q", got, "hello")
+	}
+	if cb.getCalls != 1 {
+		t.Fatalf("Get calls = %d, want 1", cb.getCalls)
+	}
+
+	if err := pf.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close error = %v, want %v", err, closeErr)
+	}
+	if cb.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", cb.closeCalls)
+	}
+}
+
+func TestPerfunctedPasteFallsBackToInputWhenClipboardUnavailable(t *testing.T) {
+	inp := &pftest.Inputter{}
+	pf := pftest.New(nil, inp, nil, nil)
+
+	if err := pf.Paste(context.Background(), "typed fallback"); err != nil {
+		t.Fatalf("Paste fallback: %v", err)
+	}
+	if got := inp.Typed(); got != "typed fallback" {
+		t.Fatalf("Paste fallback typed = %q, want %q", got, "typed fallback")
 	}
 }

--- a/perfuncted_screen_bundle_test.go
+++ b/perfuncted_screen_bundle_test.go
@@ -97,6 +97,62 @@ func TestScreenBundle_GrabRegion(t *testing.T) {
 	}
 }
 
+func TestScreenBundle_GetPixel(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	want := color.RGBA{R: 12, G: 34, B: 56, A: 255}
+	img.SetRGBA(3, 4, want)
+	sc := &pftest.Screenshotter{Frames: []image.Image{img}, ZeroOrigin: true}
+	pf := newTestPF(sc)
+	defer pf.Close()
+
+	got, err := pf.Screen.GetPixel(context.Background(), 3, 4)
+	if err != nil {
+		t.Fatalf("GetPixel: %v", err)
+	}
+	if got != want {
+		t.Fatalf("GetPixel: got %#v, want %#v", got, want)
+	}
+}
+
+func TestScreenBundle_GetMultiplePixelsTranslatesBounds(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 20, 30))
+	first := color.RGBA{R: 10, A: 255}
+	second := color.RGBA{G: 20, A: 255}
+	img.SetRGBA(11, 22, first)
+	img.SetRGBA(16, 26, second)
+	sc := &pftest.Screenshotter{Frames: []image.Image{img}, ZeroOrigin: true}
+	pf := newTestPF(sc)
+	defer pf.Close()
+
+	got, err := pf.Screen.GetMultiplePixels(context.Background(), []image.Point{
+		{X: 11, Y: 22},
+		{X: 16, Y: 26},
+	})
+	if err != nil {
+		t.Fatalf("GetMultiplePixels: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetMultiplePixels len = %d, want 2", len(got))
+	}
+	if got[0] != first || got[1] != second {
+		t.Fatalf("GetMultiplePixels = %#v, want %#v/%#v", got, first, second)
+	}
+}
+
+func TestScreenBundle_GetMultiplePixelsEmpty(t *testing.T) {
+	sc := &pftest.Screenshotter{Width: 4, Height: 4}
+	pf := newTestPF(sc)
+	defer pf.Close()
+
+	got, err := pf.Screen.GetMultiplePixels(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetMultiplePixels(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetMultiplePixels(nil) len = %d, want 0", len(got))
+	}
+}
+
 func TestScreenBundle_CaptureRegion(t *testing.T) {
 	sc := &pftest.Screenshotter{Width: 8, Height: 8}
 	pf := newTestPF(sc)


### PR DESCRIPTION
Adds focused action-and-check tests for screen pixel helpers, clipboard bundle behavior, and Wayland output event parsing.