### PR TITLE
Cover internal helper contracts

### DIFF
--- a/internal/capability/capability_test.go
+++ b/internal/capability/capability_test.go
@@ -1,0 +1,61 @@
+package capability
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnsupportedErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  UnsupportedError
+		want string
+	}{
+		{
+			name: "surface backend reason",
+			err:  UnsupportedError{Surface: "input", Backend: "wayland", Reason: "missing protocol"},
+			want: "input: unsupported on wayland: missing protocol",
+		},
+		{
+			name: "surface reason",
+			err:  UnsupportedError{Surface: "screen", Reason: "missing compositor"},
+			want: "screen: unsupported: missing compositor",
+		},
+		{
+			name: "surface only",
+			err:  UnsupportedError{Surface: "output"},
+			want: "output: unsupported",
+		},
+		{
+			name: "empty",
+			err:  UnsupportedError{},
+			want: "unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnsupportedReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	err := Unsupported("clipboard", "x11", "xclip missing")
+
+	var got UnsupportedError
+	if !errors.As(err, &got) {
+		t.Fatalf("Unsupported returned %T, want UnsupportedError", err)
+	}
+	if got.Surface != "clipboard" || got.Backend != "x11" || got.Reason != "xclip missing" {
+		t.Fatalf("Unsupported fields = %+v, want clipboard/x11/xclip missing", got)
+	}
+}

--- a/internal/compositor/compositor_test.go
+++ b/internal/compositor/compositor_test.go
@@ -1,0 +1,96 @@
+package compositor
+
+import (
+	"testing"
+
+	"github.com/nskaggs/perfuncted/internal/env"
+)
+
+func TestSessionString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Session
+		want string
+	}{
+		{name: "x11", in: X11, want: "X11"},
+		{name: "kde", in: KDE, want: "KDE Plasma Wayland"},
+		{name: "wlroots", in: Wlroots, want: "wlroots Wayland"},
+		{name: "gnome", in: GNOME, want: "GNOME Wayland"},
+		{name: "unknown", in: Unknown, want: "unknown Wayland"},
+		{name: "invalid", in: Session(99), want: "unknown Wayland"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.in.String(); got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectRuntimeWithoutWaylandReturnsX11(t *testing.T) {
+	t.Parallel()
+
+	rt := env.FromEnviron([]string{"DISPLAY=:1"})
+
+	if got := DetectRuntime(rt); got != X11 {
+		t.Fatalf("DetectRuntime = %s, want X11", got)
+	}
+}
+
+func TestDetectRuntimeUsesWaylandEnvironmentFallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  []string
+		want Session
+	}{
+		{
+			name: "sway socket",
+			env:  []string{"WAYLAND_DISPLAY=missing", "SWAYSOCK=/run/sway.sock"},
+			want: Wlroots,
+		},
+		{
+			name: "hyprland signature",
+			env:  []string{"WAYLAND_DISPLAY=missing", "HYPRLAND_INSTANCE_SIGNATURE=abc"},
+			want: Wlroots,
+		},
+		{
+			name: "kde desktop",
+			env:  []string{"WAYLAND_DISPLAY=missing", "XDG_CURRENT_DESKTOP=KDE"},
+			want: KDE,
+		},
+		{
+			name: "gnome desktop",
+			env:  []string{"WAYLAND_DISPLAY=missing", "XDG_CURRENT_DESKTOP=GNOME"},
+			want: GNOME,
+		},
+		{
+			name: "river desktop",
+			env:  []string{"WAYLAND_DISPLAY=missing", "XDG_CURRENT_DESKTOP=river"},
+			want: Wlroots,
+		},
+		{
+			name: "unknown wayland",
+			env:  []string{"WAYLAND_DISPLAY=missing"},
+			want: Unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := env.FromEnviron(tt.env)
+			if got := DetectRuntime(rt); got != tt.want {
+				t.Fatalf("DetectRuntime = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -1,0 +1,54 @@
+package probe
+
+import "testing"
+
+func TestSelectBestMarksFirstAvailable(t *testing.T) {
+	t.Parallel()
+
+	got := SelectBest([]Result{
+		{Name: "first", Available: false},
+		{Name: "second", Available: true},
+		{Name: "third", Available: true},
+	})
+
+	if got[0].Selected {
+		t.Fatalf("first selected = true, want false")
+	}
+	if !got[1].Selected {
+		t.Fatalf("second selected = false, want true")
+	}
+	if got[2].Selected {
+		t.Fatalf("third selected = true, want false")
+	}
+}
+
+func TestSelectBestLeavesUnavailableUnselected(t *testing.T) {
+	t.Parallel()
+
+	got := SelectBest([]Result{
+		{Name: "first"},
+		{Name: "second"},
+	})
+
+	for _, result := range got {
+		if result.Selected {
+			t.Fatalf("%s selected = true, want false", result.Name)
+		}
+	}
+}
+
+func TestSelectBestPreservesExistingSelectedFlags(t *testing.T) {
+	t.Parallel()
+
+	got := SelectBest([]Result{
+		{Name: "forced", Selected: true},
+		{Name: "available", Available: true},
+	})
+
+	if !got[0].Selected {
+		t.Fatalf("existing selected flag was cleared")
+	}
+	if !got[1].Selected {
+		t.Fatalf("first available result was not selected")
+	}
+}

--- a/internal/shmutil/shmutil_test.go
+++ b/internal/shmutil/shmutil_test.go
@@ -1,0 +1,35 @@
+package shmutil
+
+import (
+	"io"
+	"testing"
+)
+
+func TestCreateFileCreatesSizedWritableFile(t *testing.T) {
+	t.Parallel()
+
+	f, err := CreateFile(16)
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() != 16 {
+		t.Fatalf("size = %d, want 16", info.Size())
+	}
+
+	if _, err := f.WriteAt([]byte("ok"), 14); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	buf := make([]byte, 2)
+	if _, err := f.ReadAt(buf, 14); err != nil && err != io.EOF {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if string(buf) != "ok" {
+		t.Fatalf("read = %q, want ok", string(buf))
+	}
+}


### PR DESCRIPTION
Adds focused tests for internal capability errors, probe selection, compositor detection, and shared memory file creation.