### PR TITLE
ci: build flatpak on release, auto-generate release notes

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,9 +1,9 @@
 name: Flatpak
 
 on:
-  pull_request:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,31 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Flatpak tooling
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y flatpak
+
+      - name: Build Flatpak bundle
+        env:
+          CGO_ENABLED: "0"
+        run: go test -tags=integration ./flatpaktest -count=1 -v -timeout=60m
+
+      - name: Attach Flatpak bundle to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/flatpak/perfuncted.flatpak --clobber
+
+      - name: Generate GitHub release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES=$(gh api -X POST \
+            /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="${{ github.ref_name }}" \
+            -q .body)
+          RELEASE_ID=$(gh api /repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} -q .id)
+          gh api -X PATCH /repos/${{ github.repository }}/releases/$RELEASE_ID \
+            -F body="$NOTES"


### PR DESCRIPTION
## Summary
- limit the flatpak workflow to tag pushes matching `v*` and manual dispatches
- build the Flatpak bundle in the release workflow and upload it to the GitHub release
- generate GitHub release notes via the API and patch the release body automatically

## Testing
- not run (per request)