### PR TITLE
Reap no-pidfile sessions after grace

### DIFF
--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -29,6 +29,8 @@ var cleanupStaleSessionsMu sync.Mutex
 
 const sessionOwnerPIDFile = "perfuncted.pid"
 
+const noPIDFileReapGrace = 5 * time.Minute
+
 var sessionChildPIDFiles = []string{
 	"dbus.pid",
 	"sway.pid",
@@ -477,7 +479,7 @@ func CleanupStaleSessions(maxAge time.Duration) {
 			if statErr != nil {
 				continue
 			}
-			if now.Sub(fi.ModTime()) > maxAge {
+			if now.Sub(fi.ModTime()) > staleNoPIDThreshold(maxAge) {
 				reapSessionDir(d)
 				slog.Info("reaped stale session dir", "path", d, "reason", "no pidfile")
 			}
@@ -546,6 +548,13 @@ func readPIDFile(path string) (int, error) {
 		return 0, fmt.Errorf("invalid pid in %s", path)
 	}
 	return pid, nil
+}
+
+func staleNoPIDThreshold(maxAge time.Duration) time.Duration {
+	if maxAge <= 0 || maxAge > noPIDFileReapGrace {
+		return noPIDFileReapGrace
+	}
+	return maxAge
 }
 
 func (s *Session) stopManagedProcess(cmd *exec.Cmd, pid int, waitTimeout time.Duration) {

--- a/perfuncted_session_test.go
+++ b/perfuncted_session_test.go
@@ -262,6 +262,46 @@ func TestCleanupStaleSessionsConcurrentNoPidfileIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestCleanupStaleSessionsKeepsRecentNoPidfileDir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	recent := time.Now().Add(-1 * time.Minute)
+	if err := os.Chtimes(dir, recent, recent); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	CleanupStaleSessions(24 * time.Hour)
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("recent no-pidfile session dir was removed: %v", err)
+	}
+}
+
+func TestCleanupStaleSessionsReapsNoPidfileAfterGrace(t *testing.T) {
+	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	stale := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(dir, stale, stale); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	CleanupStaleSessions(24 * time.Hour)
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("stale no-pidfile session dir still exists: %v", err)
+	}
+}
+
 func TestCleanupStaleSessionsTerminatesRecordedChildren(t *testing.T) {
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {


### PR DESCRIPTION
Uses a short grace period for no-pidfile session directories during stale cleanup.