### PR TITLE
Harden probe backend selection

### DIFF
--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -16,6 +16,7 @@ type Result struct {
 func SelectBest(results []Result) []Result {
 	selected := false
 	for i := range results {
+		results[i].Selected = false
 		if results[i].Available && !selected {
 			results[i].Selected = true
 			selected = true

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -37,18 +37,22 @@ func TestSelectBestLeavesUnavailableUnselected(t *testing.T) {
 	}
 }
 
-func TestSelectBestPreservesExistingSelectedFlags(t *testing.T) {
+func TestSelectBestClearsStaleSelectedFlags(t *testing.T) {
 	t.Parallel()
 
 	got := SelectBest([]Result{
 		{Name: "forced", Selected: true},
 		{Name: "available", Available: true},
+		{Name: "also-stale", Available: true, Selected: true},
 	})
 
-	if !got[0].Selected {
-		t.Fatalf("existing selected flag was cleared")
+	if got[0].Selected {
+		t.Fatalf("unavailable stale selected flag remained set")
 	}
 	if !got[1].Selected {
 		t.Fatalf("first available result was not selected")
+	}
+	if got[2].Selected {
+		t.Fatalf("later stale selected flag remained set")
 	}
 }


### PR DESCRIPTION
## Summary
- make probe backend selection clear stale selected flags
- cover stale selection flags with regression tests