### PR TITLE
clipboard,output,pftest,util: consolidate duplicated helpers and fix pre-existing test bug

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/nskaggs/perfuncted/internal/env"
 	"github.com/nskaggs/perfuncted/internal/executil"
+	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
 var ErrNoClipboardTool = errors.New("no supported clipboard tool found (install wl-clipboard or xclip)")
@@ -38,7 +38,7 @@ func OpenRuntime(rt env.Runtime) (Clipboard, error) {
 	display := rt.Display()
 	sock := rt.SocketPath()
 
-	if sock != "" && waylandSocketReachable(sock) {
+	if sock != "" && wl.SocketReachable(sock) {
 		if _, err := executil.LookPath("wl-copy"); err == nil {
 			if _, err := executil.LookPath("wl-paste"); err == nil {
 				return &extCmdClipboard{
@@ -112,9 +112,4 @@ func normalizeContext(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return ctx
-}
-
-func waylandSocketReachable(sock string) bool {
-	info, err := os.Stat(sock)
-	return err == nil && info.Mode()&os.ModeSocket != 0
 }

--- a/find/find_errs_test.go
+++ b/find/find_errs_test.go
@@ -3,7 +3,6 @@ package find
 import (
 	"context"
 	"errors"
-	"fmt"
 	"image"
 	"image/color"
 	"testing"
@@ -287,22 +286,22 @@ func TestWaitWithTolerance_EmptyExpectedRect(t *testing.T) {
 	}
 }
 
-func TestWaitWithTolerance_NoSubImageError(t *testing.T) {
-	// noSubImageScreen makes WaitWithTolerance return an error.
+func TestWaitWithTolerance_NoSubImage_Timeout(t *testing.T) {
+	// noSubImageScreen returns images that don't support SubImage.
+	// LocateExactInImage falls back to the slow path; with a non-matching
+	// reference the poll should time out rather than panic.
 	sc := &noSubImageScreen{img: &noSubImage{w: 10, h: 10}}
 	ref := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	for y := 0; y < 2; y++ {
 		for x := 0; x < 2; x++ {
-			ref.SetRGBA(x, y, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+			ref.SetRGBA(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
 		}
 	}
-	_, _, err := WaitWithTolerance(context.Background(), sc, image.Rect(0, 0, 4, 4), ref, 0, 1*time.Millisecond, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, _, err := WaitWithTolerance(ctx, sc, image.Rect(0, 0, 4, 4), ref, 0, 10*time.Millisecond, nil)
 	if err == nil {
-		t.Fatal("expected error when image has no SubImage support")
-	}
-	if !errors.Is(err, fmt.Errorf("x")) {
-		// Just check it's non-nil; exact message is an implementation detail.
-		_ = err
+		t.Fatal("expected timeout when reference not found")
 	}
 }
 

--- a/internal/compositor/compositor.go
+++ b/internal/compositor/compositor.go
@@ -127,6 +127,9 @@ func probeGlobals(rt env.Runtime) (Session, bool) {
 }
 
 func kwinOnBus(addr string) bool {
+	if addr == "" {
+		return false
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return false

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -6,7 +6,6 @@ import (
 	"image"
 	"image/color"
 	"math/bits"
-	"reflect"
 	"time"
 
 	"github.com/nskaggs/perfuncted/find"
@@ -37,7 +36,7 @@ func WaitForPixelColor(sc find.Screenshotter, rect image.Rectangle, target color
 // WaitForImage waits until template is found in the full screen using method.
 // Supported methods: "exact" (pixel-perfect). Returns a slice of MatchResult.
 func WaitForImage(sc find.Screenshotter, template image.Image, method string, timeout time.Duration) ([]MatchResult, error) {
-	if err := checkAvailable(sc); err != nil {
+	if err := CheckAvailable("util", sc); err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -69,20 +68,6 @@ func WaitForImage(sc find.Screenshotter, template image.Image, method string, ti
 	default:
 		return nil, fmt.Errorf("util: unsupported match method %q", method)
 	}
-}
-
-func checkAvailable(resource any) error {
-	if resource == nil {
-		return fmt.Errorf("util: resource not available")
-	}
-	v := reflect.ValueOf(resource)
-	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		if v.IsNil() {
-			return fmt.Errorf("util: resource not available")
-		}
-	}
-	return nil
 }
 
 // ImageHashCompare returns true when the Hamming distance between two 32-bit

--- a/output/output.go
+++ b/output/output.go
@@ -3,11 +3,11 @@ package output
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/nskaggs/perfuncted/internal/compositor"
 	"github.com/nskaggs/perfuncted/internal/env"
 	"github.com/nskaggs/perfuncted/internal/probe"
+	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
 // Geometry describes an output rectangle in compositor coordinates.
@@ -55,7 +55,7 @@ func OpenRuntime(rt env.Runtime) (Lister, error) {
 		return NewX11Lister(display)
 	}
 	if sock != "" {
-		if waylandSocketReachable(sock) {
+		if wl.SocketReachable(sock) {
 			return NewWaylandLister(sock)
 		}
 		if display != "" {
@@ -74,7 +74,7 @@ func ProbeRuntime(rt env.Runtime) []probe.Result {
 		return []probe.Result{{Name: "x11", Available: true, Selected: true, Reason: "DISPLAY set"}}
 	}
 	if sock != "" {
-		if !waylandSocketReachable(sock) && display != "" {
+		if !wl.SocketReachable(sock) && display != "" {
 			return []probe.Result{{Name: "x11", Available: true, Selected: true, Reason: "WAYLAND socket missing"}}
 		}
 		return []probe.Result{{Name: "wayland", Available: true, Selected: true, Reason: compositor.DetectRuntime(rt).String()}}
@@ -90,9 +90,4 @@ func List(ctx context.Context) ([]Info, error) {
 	}
 	defer l.Close()
 	return l.List(ctx)
-}
-
-func waylandSocketReachable(sock string) bool {
-	info, err := os.Stat(sock)
-	return err == nil && info.Mode()&os.ModeSocket != 0
 }

--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -31,8 +31,8 @@ var (
 )
 
 const (
-	sessionOwnerPIDFile    = "perfuncted.pid"
-	noPIDFileReapGrace     = 5 * time.Minute
+	sessionOwnerPIDFile     = "perfuncted.pid"
+	noPIDFileReapGrace      = 5 * time.Minute
 	cleanupStaleMinInterval = 30 * time.Second
 )
 

--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -36,6 +36,14 @@ const (
 	cleanupStaleMinInterval = 30 * time.Second
 )
 
+// ResetCleanupStaleRateLimit clears the rate-limit state so the next call
+// to CleanupStaleSessions proceeds immediately. Exported for tests only.
+func ResetCleanupStaleRateLimit() {
+	cleanupStaleSessionsMu.Lock()
+	lastCleanupTime = time.Time{}
+	cleanupStaleSessionsMu.Unlock()
+}
+
 var sessionChildPIDFiles = []string{
 	"dbus.pid",
 	"sway.pid",
@@ -468,7 +476,7 @@ func CleanupStaleSessions(maxAge time.Duration) {
 	cleanupStaleSessionsMu.Lock()
 	defer cleanupStaleSessionsMu.Unlock()
 
-	if time.Now().Sub(lastCleanupTime) < cleanupStaleMinInterval {
+	if time.Since(lastCleanupTime) < cleanupStaleMinInterval {
 		return
 	}
 	lastCleanupTime = time.Now()

--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -25,11 +25,16 @@ import (
 //go:embed configs/headless.conf configs/nested.conf
 var embeddedConfigs embed.FS
 
-var cleanupStaleSessionsMu sync.Mutex
+var (
+	cleanupStaleSessionsMu sync.Mutex
+	lastCleanupTime        time.Time
+)
 
-const sessionOwnerPIDFile = "perfuncted.pid"
-
-const noPIDFileReapGrace = 5 * time.Minute
+const (
+	sessionOwnerPIDFile    = "perfuncted.pid"
+	noPIDFileReapGrace     = 5 * time.Minute
+	cleanupStaleMinInterval = 30 * time.Second
+)
 
 var sessionChildPIDFiles = []string{
 	"dbus.pid",
@@ -462,6 +467,11 @@ func (s *Session) launchWlPaste() {
 func CleanupStaleSessions(maxAge time.Duration) {
 	cleanupStaleSessionsMu.Lock()
 	defer cleanupStaleSessionsMu.Unlock()
+
+	if time.Now().Sub(lastCleanupTime) < cleanupStaleMinInterval {
+		return
+	}
+	lastCleanupTime = time.Now()
 
 	matches, err := filepath.Glob(nestedSessionPattern())
 	if err != nil {

--- a/perfuncted_session_test.go
+++ b/perfuncted_session_test.go
@@ -216,6 +216,7 @@ func TestSessionStopNil(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsRemovesDeadPIDDir(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -235,6 +236,7 @@ func TestCleanupStaleSessionsRemovesDeadPIDDir(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsConcurrentNoPidfileIsIdempotent(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -263,6 +265,7 @@ func TestCleanupStaleSessionsConcurrentNoPidfileIsIdempotent(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsKeepsRecentNoPidfileDir(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -283,6 +286,7 @@ func TestCleanupStaleSessionsKeepsRecentNoPidfileDir(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsReapsNoPidfileAfterGrace(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -303,6 +307,7 @@ func TestCleanupStaleSessionsReapsNoPidfileAfterGrace(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsTerminatesRecordedChildren(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
@@ -347,6 +352,7 @@ func TestCleanupStaleSessionsTerminatesRecordedChildren(t *testing.T) {
 }
 
 func TestCleanupStaleSessionsKeepsLivePIDDir(t *testing.T) {
+	ResetCleanupStaleRateLimit()
 	dir, err := os.MkdirTemp("", "perfuncted-xdg-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)

--- a/pftest/pftest.go
+++ b/pftest/pftest.go
@@ -103,11 +103,7 @@ func (s *Screenshotter) Close() error { return nil }
 
 func SolidImage(w, h int, c color.RGBA) image.Image {
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			img.Set(x, y, c)
-		}
-	}
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: c}, image.Point{}, draw.Src)
 	return img
 }
 

--- a/screen/gnome_shell.go
+++ b/screen/gnome_shell.go
@@ -57,6 +57,9 @@ func NewGnomeShellScreenshotBackend() (*GnomeShellScreenshotBackend, error) {
 // NewGnomeShellScreenshotBackendForBus returns a backend for the session bus at
 // addr when GNOME Shell's screenshot service is reachable and authorized.
 func NewGnomeShellScreenshotBackendForBus(addr string) (*GnomeShellScreenshotBackend, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("screen/gnome-shell: D-Bus session unset")
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return nil, fmt.Errorf("screen/gnome-shell: D-Bus session: %w", err)

--- a/screen/kwinshot.go
+++ b/screen/kwinshot.go
@@ -57,6 +57,9 @@ func NewKWinShotBackend() (*KWinShotBackend, error) {
 // NewKWinShotBackendForBus opens a KWin screenshot backend on the session bus
 // at addr and verifies that the caller is authorized to capture the screen.
 func NewKWinShotBackendForBus(addr string) (*KWinShotBackend, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("screen/kwin: D-Bus session unset")
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return nil, fmt.Errorf("screen/kwin: D-Bus session: %w", err)

--- a/screen/portal_dbus.go
+++ b/screen/portal_dbus.go
@@ -96,6 +96,9 @@ func NewPortalDBusBackend() (*PortalDBusBackend, error) {
 // NewPortalDBusBackendForBus verifies that the xdg-desktop-portal Screenshot
 // interface is reachable on the session bus at addr.
 func NewPortalDBusBackendForBus(addr string) (*PortalDBusBackend, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("screen/portal: D-Bus session unset")
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return nil, fmt.Errorf("screen/portal: D-Bus session: %w", err)

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -206,6 +206,10 @@ func checkExtCapture(globals map[string]bool) probe.Result {
 
 func checkPortalDbus(rt env.Runtime) probe.Result {
 	r := probe.Result{Name: "portal"}
+	if rt.Get("DBUS_SESSION_BUS_ADDRESS") == "" {
+		r.Reason = "D-Bus session unavailable"
+		return r
+	}
 	conn, err := dbusutil.SessionBusAddress(rt.Get("DBUS_SESSION_BUS_ADDRESS"))
 	if err != nil {
 		r.Reason = "D-Bus session unavailable"

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -16,18 +16,8 @@ import (
 // GrabFullHash returns a CRC32 checksum of the entire screen.
 func (b *X11Backend) GrabFullHash(ctx context.Context) (uint32, error) {
 	rect := image.Rect(0, 0, int(b.screen.WidthInPixels), int(b.screen.HeightInPixels))
-	drawable := xproto.Drawable(b.root)
-
-	if b.hasComposite {
-		rawID, err := b.conn.NewId()
-		if err == nil {
-			pid := xproto.Pixmap(rawID)
-			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
-				drawable = xproto.Drawable(pid)
-				defer b.conn.FreePixmap(pid) //nolint:errcheck
-			}
-		}
-	}
+	drawable, free := b.compositeDrawableForRoot()
+	defer free()
 
 	x := int16(rect.Min.X)
 	y := int16(rect.Min.Y)
@@ -54,17 +44,8 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 		return b.GrabFullHash(ctx)
 	}
 
-	drawable := xproto.Drawable(b.root)
-	if b.hasComposite {
-		rawID, err := b.conn.NewId()
-		if err == nil {
-			pid := xproto.Pixmap(rawID)
-			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
-				drawable = xproto.Drawable(pid)
-				defer b.conn.FreePixmap(pid) //nolint:errcheck
-			}
-		}
-	}
+	drawable, free := b.compositeDrawableForRoot()
+	defer free()
 
 	x := int16(rect.Min.X)
 	y := int16(rect.Min.Y)
@@ -85,7 +66,21 @@ func (b *X11Backend) GrabRegionHash(ctx context.Context, rect image.Rectangle) (
 }
 
 // X11Backend captures screen regions via XGetImage on an X11 or XWayland display.
-//
+
+func (b *X11Backend) compositeDrawableForRoot() (xproto.Drawable, func()) {
+	drawable := xproto.Drawable(b.root)
+	if b.hasComposite {
+		rawID, err := b.conn.NewId()
+		if err == nil {
+			pid := xproto.Pixmap(rawID)
+			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
+				return xproto.Drawable(pid), func() { _ = b.conn.FreePixmap(pid) } //nolint:errcheck
+			}
+		}
+	}
+	return drawable, func() {}
+}
+
 // On composited sessions (KDE/GNOME Wayland via XWayland) the root window is
 // not directly readable with XGetImage. This backend automatically uses the
 // Composite extension (NameWindowPixmap) when available, falling back to a
@@ -122,20 +117,8 @@ func (b *X11Backend) Grab(ctx context.Context, rect image.Rectangle) (image.Imag
 	if rect.Empty() {
 		rect = image.Rect(0, 0, int(b.screen.WidthInPixels), int(b.screen.HeightInPixels))
 	}
-	drawable := xproto.Drawable(b.root)
-
-	if b.hasComposite {
-		// NameWindowPixmap gives us a pixmap containing the composited root
-		// contents — necessary on XWayland where direct root GetImage fails.
-		rawID, err := b.conn.NewId()
-		if err == nil {
-			pid := xproto.Pixmap(rawID)
-			if b.conn.NameWindowPixmap(b.root, pid).Check() == nil {
-				drawable = xproto.Drawable(pid)
-				defer b.conn.FreePixmap(pid) //nolint:errcheck
-			}
-		}
-	}
+	drawable, free := b.compositeDrawableForRoot()
+	defer free()
 
 	x := int16(rect.Min.X)
 	y := int16(rect.Min.Y)

--- a/window/gnome.go
+++ b/window/gnome.go
@@ -32,6 +32,9 @@ func NewGnomeManager() (*GnomeManager, error) {
 // NewGnomeManagerForBus opens a D-Bus connection at addr and verifies that
 // org.gnome.Shell.Eval is accessible.
 func NewGnomeManagerForBus(addr string) (*GnomeManager, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("gnome: session bus unset")
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return nil, fmt.Errorf("gnome: session bus: %w", err)

--- a/window/kwinscript.go
+++ b/window/kwinscript.go
@@ -52,6 +52,9 @@ func NewKWinScriptManager() (*KWinScriptManager, error) {
 // NewKWinScriptManagerForBus returns a KWinScriptManager for the session bus
 // at addr if the KWin scripting interface is accessible.
 func NewKWinScriptManagerForBus(addr string) (*KWinScriptManager, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("window/kwinscript: D-Bus session unset")
+	}
 	conn, err := dbusutil.SessionBusAddress(addr)
 	if err != nil {
 		return nil, fmt.Errorf("window/kwinscript: D-Bus: %w", err)

--- a/window/window.go
+++ b/window/window.go
@@ -156,6 +156,10 @@ func checkKWinScript(rt env.Runtime, kind compositor.Session) probe.Result {
 		r.Reason = "not a KDE Plasma session"
 		return r
 	}
+	if rt.Get("DBUS_SESSION_BUS_ADDRESS") == "" {
+		r.Reason = "D-Bus unavailable"
+		return r
+	}
 	conn, err := dbusutil.SessionBusAddress(rt.Get("DBUS_SESSION_BUS_ADDRESS"))
 	if err != nil {
 		r.Reason = fmt.Sprintf("D-Bus unavailable: %v", err)


### PR DESCRIPTION
Replace duplicate waylandSocketReachable (3 copies) with shared wl.SocketReachable. Replace private checkAvailable in internal/util with the public one from availability.go. Optimize pftest.SolidImage: draw.Draw with image.Uniform instead of per-pixel Set(). Fix pre-existing broken TestWaitWithTolerance_NoSubImageError (code falls back to slow path for non-SubImage images, so expect timeout not error). Includes prior fix-probe-selectbest-authoritative changes (D-Bus guard, session rate-limit, X11 refactor).