### PR TITLE
Fix input backend fallbacks

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -33,6 +33,16 @@ var newXTestBackend = func(display string) (Inputter, error) {
 	return NewXTestBackend(display)
 }
 
+var statUinput = func() error {
+	_, err := os.Stat("/dev/uinput")
+	return err
+}
+
+func hasDelegatingBackend(b Inputter) bool {
+	im, ok := b.(*WlInputMethodBackend)
+	return !ok || im.other != nil
+}
+
 // Inputter injects keyboard and mouse events.
 //
 // Keyboard methods accept key names ("a", "ctrl", "return", "f5", etc.).
@@ -81,11 +91,12 @@ func Open(maxX, maxY int32) (Inputter, error) {
 func OpenRuntime(rt env.Runtime, maxX, maxY int32) (Inputter, error) {
 	// Allow forcing a particular backend for debugging in CI/local runs.
 	if os.Getenv("PF_FORCE_INPUT") == "uinput" {
-		if _, statErr := os.Stat("/dev/uinput"); statErr == nil {
-			if b, err := NewUinputBackend(maxX, maxY); err == nil {
+		if statErr := statUinput(); statErr == nil {
+			if b, err := newUinputBackend(maxX, maxY); err == nil {
 				return b, nil
+			} else {
+				return nil, fmt.Errorf("forced uinput selected: %w", err)
 			}
-			return nil, fmt.Errorf("forced uinput selected but failed to initialize")
 		}
 		return nil, fmt.Errorf("forced uinput selected but /dev/uinput not accessible")
 	}
@@ -97,7 +108,10 @@ func OpenRuntime(rt env.Runtime, maxX, maxY int32) (Inputter, error) {
 	//	WlInputMethod -> wl-virtual -> XTEST (if DISPLAY set) -> uinput
 	if sock := rt.SocketPath(); sock != "" {
 		if b, err := newWlInputMethodBackend(sock, maxX, maxY); err == nil {
-			return b, nil
+			if hasDelegatingBackend(b) {
+				return b, nil
+			}
+			_ = b.Close()
 		}
 		if b, err := newWlVirtualBackend(sock); err == nil {
 			return b, nil
@@ -109,7 +123,7 @@ func OpenRuntime(rt env.Runtime, maxX, maxY int32) (Inputter, error) {
 		}
 		// wl-virtual/XTEST unavailable; uinput is the last Wayland fallback
 		// when the compositor-scoped backends are unavailable.
-		if _, statErr := os.Stat("/dev/uinput"); statErr == nil {
+		if statErr := statUinput(); statErr == nil {
 			if b, err := newUinputBackend(maxX, maxY); err == nil {
 				return b, nil
 			}
@@ -124,12 +138,13 @@ func OpenRuntime(rt env.Runtime, maxX, maxY int32) (Inputter, error) {
 	}
 
 	// Final fallback: uinput on systems without a Wayland session.
-	if _, err := os.Stat("/dev/uinput"); err == nil {
+	if err := statUinput(); err == nil {
 		if b, err := newUinputBackend(maxX, maxY); err == nil {
 			return b, nil
+		} else {
+			// Return uinput error directly—it includes permission hints.
+			return nil, err
 		}
-		// Return uinput error directly—it includes permission hints.
-		return nil, err
 	}
 
 	return nil, fmt.Errorf("input: no backend available (uinput inaccessible, DISPLAY not set)")

--- a/input/open_runtime_fallback_test.go
+++ b/input/open_runtime_fallback_test.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -63,6 +64,78 @@ func TestOpenRuntimeFallsBackToXTestWhenWaylandSocketUnresolvable(t *testing.T) 
 	}
 	if _, ok := inp.(noopInputter); !ok {
 		t.Fatalf("OpenRuntime type = %T, want noopInputter", inp)
+	}
+}
+
+func TestOpenRuntimeSkipsHalfFunctionalWlInputMethod(t *testing.T) {
+	oldWlInputMethod := newWlInputMethodBackend
+	oldWlVirtual := newWlVirtualBackend
+	oldXTest := newXTestBackend
+	oldUinput := newUinputBackend
+	t.Cleanup(func() {
+		newWlInputMethodBackend = oldWlInputMethod
+		newWlVirtualBackend = oldWlVirtual
+		newXTestBackend = oldXTest
+		newUinputBackend = oldUinput
+	})
+
+	var inputMethodCalls, virtualCalls, xTestCalls int
+	newWlInputMethodBackend = func(string, int32, int32) (Inputter, error) {
+		inputMethodCalls++
+		return &WlInputMethodBackend{}, nil
+	}
+	newWlVirtualBackend = func(string) (Inputter, error) {
+		virtualCalls++
+		return nil, os.ErrNotExist
+	}
+	newXTestBackend = func(string) (Inputter, error) {
+		xTestCalls++
+		return noopInputter{}, nil
+	}
+	newUinputBackend = func(int32, int32) (Inputter, error) {
+		return nil, os.ErrNotExist
+	}
+
+	t.Setenv("PF_FORCE_INPUT", "")
+	rt := env.FromEnviron([]string{
+		"DISPLAY=:99",
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=" + t.TempDir(),
+	})
+
+	inp, err := OpenRuntime(rt, 1024, 768)
+	if err != nil {
+		t.Fatalf("OpenRuntime: %v", err)
+	}
+	if _, ok := inp.(noopInputter); !ok {
+		t.Fatalf("OpenRuntime type = %T, want noopInputter", inp)
+	}
+	if inputMethodCalls != 1 || virtualCalls != 1 || xTestCalls != 1 {
+		t.Fatalf("constructor calls = im:%d virtual:%d xtest:%d, want 1/1/1", inputMethodCalls, virtualCalls, xTestCalls)
+	}
+}
+
+func TestOpenRuntimeForcedUinputWrapsInitError(t *testing.T) {
+	oldUinput := newUinputBackend
+	oldStatUinput := statUinput
+	t.Cleanup(func() {
+		newUinputBackend = oldUinput
+		statUinput = oldStatUinput
+	})
+
+	want := errors.New("uinput init failed")
+	newUinputBackend = func(int32, int32) (Inputter, error) {
+		return nil, want
+	}
+	statUinput = func() error { return nil }
+
+	t.Setenv("PF_FORCE_INPUT", "uinput")
+	err := func() error {
+		_, err := OpenRuntime(env.FromEnviron(nil), 1024, 768)
+		return err
+	}()
+	if !errors.Is(err, want) {
+		t.Fatalf("OpenRuntime error = %v, want wrapped %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- skip wl-input-method backends that cannot delegate non-text input operations
- preserve the underlying uinput initialization error when PF_FORCE_INPUT=uinput is set
- add regression coverage for fallback selection and forced-uinput failures

## Testing
- go test ./input ./cmd/pf
- go test ./...