### PR TITLE
Fix output probe fallback

### DIFF
--- a/output/open_test.go
+++ b/output/open_test.go
@@ -58,6 +58,27 @@ func TestProbeRuntimeFallsBackToX11WhenWaylandSocketUnresolvable(t *testing.T) {
 	}
 }
 
+func TestProbeRuntime_UnreachableWaylandWithoutX11ReportsUnavailable(t *testing.T) {
+	rt := env.FromEnviron([]string{
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=" + t.TempDir(),
+	})
+
+	got := ProbeRuntime(rt)
+	if len(got) != 1 {
+		t.Fatalf("ProbeRuntime len = %d, want 1", len(got))
+	}
+	if got[0].Name != "wayland" {
+		t.Fatalf("ProbeRuntime name = %q, want wayland", got[0].Name)
+	}
+	if got[0].Available || got[0].Selected {
+		t.Fatalf("ProbeRuntime available=%v selected=%v, want false/false", got[0].Available, got[0].Selected)
+	}
+	if !strings.Contains(got[0].Reason, "socket unreachable") {
+		t.Fatalf("ProbeRuntime reason = %q, want unreachable socket message", got[0].Reason)
+	}
+}
+
 func TestProbeRuntime_NoSessionReportsUnavailable(t *testing.T) {
 	rt := env.FromEnviron([]string{})
 

--- a/output/output.go
+++ b/output/output.go
@@ -74,8 +74,11 @@ func ProbeRuntime(rt env.Runtime) []probe.Result {
 		return []probe.Result{{Name: "x11", Available: true, Selected: true, Reason: "DISPLAY set"}}
 	}
 	if sock != "" {
-		if !wl.SocketReachable(sock) && display != "" {
-			return []probe.Result{{Name: "x11", Available: true, Selected: true, Reason: "WAYLAND socket missing"}}
+		if !wl.SocketReachable(sock) {
+			if display != "" {
+				return []probe.Result{{Name: "x11", Available: true, Selected: true, Reason: "WAYLAND socket missing"}}
+			}
+			return []probe.Result{{Name: "wayland", Available: false, Reason: fmt.Sprintf("WAYLAND_DISPLAY=%q socket unreachable", sock)}}
 		}
 		return []probe.Result{{Name: "wayland", Available: true, Selected: true, Reason: compositor.DetectRuntime(rt).String()}}
 	}


### PR DESCRIPTION
## Summary
- report unreachable Wayland sockets as unavailable when no X11 fallback exists
- keep the existing X11 fallback behavior when DISPLAY is still usable
- add regression coverage for probe/runtime consistency

## Testing
- go test ./output ./cmd/pf
- go test ./...