### PR TITLE
Surface PID-file errors, add compile-time backend checks, configurable sway reflow

### DIFF
--- a/perfuncted_session.go
+++ b/perfuncted_session.go
@@ -181,7 +181,10 @@ func startSession(cfg SessionConfig, mode sessionMode) (*Session, error) {
 
 	// Write a pidfile so future starts can detect and reap stale sessions.
 	pidPath := filepath.Join(s.xdgDir, sessionOwnerPIDFile)
-	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		slog.Warn("failed to write owner pidfile, stale session reaping may be degraded",
+			"path", pidPath, "error", err)
+	}
 
 	// Register signal cleanup automatically so sessions are reaped on SIGINT/SIGTERM.
 	s.unregister = s.CleanupOnSignal(context.Background())
@@ -540,7 +543,10 @@ func (s *Session) writeChildPID(name string, pid int) {
 	if s == nil || s.xdgDir == "" || pid <= 0 {
 		return
 	}
-	_ = os.WriteFile(filepath.Join(s.xdgDir, name), []byte(strconv.Itoa(pid)), 0o600)
+	if err := os.WriteFile(filepath.Join(s.xdgDir, name), []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		slog.Warn("failed to write child pidfile",
+			"name", name, "pid", pid, "path", filepath.Join(s.xdgDir, name), "error", err)
+	}
 }
 
 func reapSessionDir(dir string) {

--- a/screen/extcapture.go
+++ b/screen/extcapture.go
@@ -13,6 +13,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
+var _ Screenshotter = (*ExtCaptureBackend)(nil)
+
 // ExtCaptureBackend captures the screen using ext_image_copy_capture_manager_v1.
 // This protocol is detected by probing compositor globals at runtime; it is
 // available where the compositor advertises ext_image_copy_capture_manager_v1.

--- a/screen/gnome_shell.go
+++ b/screen/gnome_shell.go
@@ -15,6 +15,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
+var _ Screenshotter = (*GnomeShellScreenshotBackend)(nil)
+
 // GrabFullHash returns a fast pixel hash of the entire screen.
 func (b *GnomeShellScreenshotBackend) GrabFullHash(ctx context.Context) (uint32, error) {
 	img, err := b.Grab(ctx, image.Rectangle{})

--- a/screen/kwinshot.go
+++ b/screen/kwinshot.go
@@ -24,6 +24,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
+var _ Screenshotter = (*KWinShotBackend)(nil)
+
 const (
 	kwinShotDest  = "org.kde.KWin"
 	kwinShotPath  = "/org/kde/KWin/ScreenShot2"

--- a/screen/portal_dbus.go
+++ b/screen/portal_dbus.go
@@ -18,6 +18,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
+var _ Screenshotter = (*PortalDBusBackend)(nil)
+
 // GrabFullHash returns a fast pixel hash of the entire screen.
 func (b *PortalDBusBackend) GrabFullHash(ctx context.Context) (uint32, error) {
 	img, err := b.Grab(ctx, image.Rectangle{})

--- a/screen/x11.go
+++ b/screen/x11.go
@@ -13,6 +13,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/x11"
 )
 
+var _ Screenshotter = (*X11Backend)(nil)
+
 // GrabFullHash returns a CRC32 checksum of the entire screen.
 func (b *X11Backend) GrabFullHash(ctx context.Context) (uint32, error) {
 	rect := image.Rect(0, 0, int(b.screen.WidthInPixels), int(b.screen.HeightInPixels))

--- a/window/gnome.go
+++ b/window/gnome.go
@@ -14,6 +14,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
+var _ Manager = (*GnomeManager)(nil)
+
 // gnomeShellService is the D-Bus service name for GNOME Shell's Eval interface.
 const gnomeShellService = "org.gnome.Shell"
 
@@ -180,7 +182,10 @@ func (g *GnomeManager) Unfullscreen(ctx context.Context, title string) error {
 }
 
 func (g *GnomeManager) Close() error {
-	return nil
+	if g.conn == nil {
+		return nil
+	}
+	return g.conn.Close()
 }
 
 func (g *GnomeManager) Sync(ctx context.Context) error {

--- a/window/kwinscript.go
+++ b/window/kwinscript.go
@@ -32,6 +32,8 @@ import (
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
+var _ Manager = (*KWinScriptManager)(nil)
+
 const (
 	kwinScriptSvc   = "org.kde.KWin"
 	kwinScriptPath  = dbus.ObjectPath("/Scripting")

--- a/window/sway.go
+++ b/window/sway.go
@@ -42,6 +42,10 @@ type swayRect struct {
 	H int `json:"height"`
 }
 
+var _ Manager = (*SwayManager)(nil)
+
+const defaultReflowTimeout = 500 * time.Millisecond
+
 // SwayManager implements Manager via sway's IPC socket (i3-ipc protocol).
 // It does not require any Wayland protocol machinery — it uses a simple
 // Unix socket with length-prefixed JSON messages.
@@ -49,6 +53,10 @@ type SwayManager struct {
 	sock string
 	mu   sync.Mutex
 	conn net.Conn
+
+	// ReflowTimeout controls how long Move waits for float layout reflow
+	// after enabling floating on a tiled window. Zero means the default (500ms).
+	ReflowTimeout time.Duration
 }
 
 // NewSwayManager returns a SwayManager connected to the nearest sway IPC
@@ -316,11 +324,15 @@ func (m *SwayManager) Move(ctx context.Context, substr string, x, y int) error {
 	}
 
 	// Wait for sway to report the window away from its tiled origin, indicating
-	// the float layout reflow is complete (up to ~500 ms).
+	// the float layout reflow is complete.
+	reflowTimeout := m.ReflowTimeout
+	if reflowTimeout <= 0 {
+		reflowTimeout = defaultReflowTimeout
+	}
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 
-	timeout := time.After(500 * time.Millisecond)
+	timeout := time.After(reflowTimeout)
 loop:
 	for {
 		wins, err := m.List(ctx)


### PR DESCRIPTION
- PID-file write errors no longer silently discarded (writeChildPID + owner pidfile)\n- Compile-time interface checks for all 8 missing backends\n- SwayManager.ReflowTimeout makes 500ms reflow wait configurable\n- GnomeManager.Close() now closes D-Bus connection