### PR TITLE
perfuncted/ctxutil: extract shared normalizeContext into public package

### DIFF
--- a/bundle_input.go
+++ b/bundle_input.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"time"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/input"
 	"github.com/nskaggs/perfuncted/internal/util"
 )
@@ -112,7 +113,7 @@ func (i InputBundle) DoubleClick(ctx context.Context, x, y int) error {
 }
 
 func (i InputBundle) doubleClickContext(ctx context.Context, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	i.traceAction(fmt.Sprintf("double-click x=%d y=%d", x, y))
 	if err := i.checkAvailable(); err != nil {
 		return err
@@ -247,7 +248,7 @@ func (i InputBundle) DragAndDrop(ctx context.Context, x1, y1, x2, y2 int) error 
 }
 
 func (i InputBundle) dragAndDropContext(ctx context.Context, x1, y1, x2, y2 int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	i.traceAction(fmt.Sprintf("drag-and-drop x1=%d y1=%d x2=%d y2=%d", x1, y1, x2, y2))
 	if err := i.checkAvailable(); err != nil {
 		return err

--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/env"
 	"github.com/nskaggs/perfuncted/internal/executil"
 	"github.com/nskaggs/perfuncted/internal/wl"
@@ -70,7 +71,7 @@ type extCmdClipboard struct {
 }
 
 func (c *extCmdClipboard) Get(ctx context.Context) (string, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	cmd := executil.CommandContext(ctx, c.getCmd[0], c.getCmd[1:]...)
 	// Ensure the external tool runs with the session env captured at Open().
 	cmd.Env = c.env
@@ -86,7 +87,7 @@ func (c *extCmdClipboard) Get(ctx context.Context) (string, error) {
 }
 
 func (c *extCmdClipboard) Set(ctx context.Context, text string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	cmd := executil.CommandContext(ctx, c.setCmd[0], c.setCmd[1:]...)
 	// Ensure the external tool runs with the session env captured at Open().
 	cmd.Env = c.env
@@ -105,11 +106,4 @@ func (c *extCmdClipboard) Close() error { return nil }
 
 func captureRuntimeEnv(rt env.Runtime) []string {
 	return rt.EnvList()
-}
-
-func normalizeContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
 }

--- a/cmd/pf/main.go
+++ b/cmd/pf/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/nskaggs/perfuncted"
+	"github.com/nskaggs/perfuncted/ctxutil"
 )
 
 var (
@@ -28,9 +29,7 @@ func run(ctx context.Context, args []string) int {
 }
 
 func runWithFactory(ctx context.Context, args []string, openPFFactory func(*cliConfig) func() (*perfuncted.Perfuncted, error)) int {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	cmd := newRootCmd(openPFFactory)
 	cmd.SetArgs(args)
 	if err := cmd.ExecuteContext(ctx); err != nil {

--- a/ctxutil/ctxutil.go
+++ b/ctxutil/ctxutil.go
@@ -1,0 +1,14 @@
+// Package ctxutil provides context utilities.
+package ctxutil
+
+import "context"
+
+// Default returns ctx if non-nil, otherwise context.Background().
+// Use this at the top of public functions to guarantee a non-nil context
+// without panicking on nil.
+func Default(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}

--- a/find/find.go
+++ b/find/find.go
@@ -15,6 +15,8 @@ import (
 	"image/draw"
 	"reflect"
 	"time"
+
+	"github.com/nskaggs/perfuncted/ctxutil"
 )
 
 // ErrNotFound is returned when a pixel pattern or color could not be located.
@@ -61,13 +63,6 @@ func contextErr(ctx context.Context) error {
 		return nil
 	}
 	return ctx.Err()
-}
-
-func normalizeContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
 }
 
 func checkAvailable(sc Screenshotter) error {
@@ -122,7 +117,7 @@ func PixelHash(img image.Image, newHash Hasher) uint32 {
 // implementations provide a fast GrabRegionHash that avoids allocating an
 // image.RGBA; use that when available.
 func GrabHash(ctx context.Context, sc Screenshotter, rect image.Rectangle, newHash Hasher) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, err
 	}
@@ -138,7 +133,7 @@ func GrabHash(ctx context.Context, sc Screenshotter, rect image.Rectangle, newHa
 
 // FirstPixel returns the colour of the top-left pixel of rect captured from sc.
 func FirstPixel(ctx context.Context, sc Screenshotter, rect image.Rectangle) (color.RGBA, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return color.RGBA{}, err
 	}
@@ -155,7 +150,7 @@ func FirstPixel(ctx context.Context, sc Screenshotter, rect image.Rectangle) (co
 
 // LastPixel returns the colour of the bottom-right pixel of rect captured from sc.
 func LastPixel(ctx context.Context, sc Screenshotter, rect image.Rectangle) (color.RGBA, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return color.RGBA{}, err
 	}
@@ -178,7 +173,7 @@ type Result struct {
 }
 
 func poll(ctx context.Context, pollDur time.Duration, onCancel uint32, fn func(attempt int) (done bool, result uint32, err error)) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if pollDur <= 0 {
 		attempt := 0
 		for {
@@ -235,7 +230,7 @@ func poll(ctx context.Context, pollDur time.Duration, onCancel uint32, fn func(a
 // On success, it returns the final hash (which equals want). On timeout, it returns
 // the last observed hash for debugging.
 func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want uint32, pollDur time.Duration, newHash Hasher) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, err
 	}
@@ -262,7 +257,7 @@ func WaitFor(ctx context.Context, sc Screenshotter, rect image.Rectangle, want u
 // It pairs with WaitForNoChange: use WaitForChange to detect when a transition begins,
 // then WaitForNoChange to detect when it ends.
 func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, initial uint32, pollDur time.Duration, newHash Hasher) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, err
 	}
@@ -293,7 +288,7 @@ func WaitForChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, 
 // stable must be ≥ 1. A value of 5 with poll=200ms means the region must look
 // identical for one full second before returning.
 func WaitForNoChange(ctx context.Context, sc Screenshotter, rect image.Rectangle, stable int, poll time.Duration, newHash Hasher) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, err
 	}
@@ -304,7 +299,7 @@ func WaitForNoChange(ctx context.Context, sc Screenshotter, rect image.Rectangle
 // to avoid the first capture if the caller already knows the current state.
 // If initial is 0, the first capture is performed immediately.
 func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Rectangle, initial uint32, stable int, pollDur time.Duration, newHash Hasher) (uint32, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, err
 	}
@@ -370,7 +365,7 @@ func WaitForNoChangeFrom(ctx context.Context, sc Screenshotter, rect image.Recta
 // rect areas), ScanFor performs a single sc.Grab of the union bounding box per poll
 // cycle and hashes sub-regions in memory — reducing IPC round-trips from N to 1.
 func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wants []uint32, poll time.Duration, newHash Hasher) (Result, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return Result{}, err
 	}
@@ -538,7 +533,7 @@ func LocateExactInImage(src image.Image, searchArea image.Rectangle, reference i
 // LocateExact performs an exact byte-for-byte search of reference within the searchArea.
 // It returns the absolute image.Rectangle where it matches.
 func LocateExact(ctx context.Context, sc Screenshotter, searchArea image.Rectangle, reference image.Image) (image.Rectangle, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return image.Rectangle{}, err
 	}
@@ -589,7 +584,7 @@ func matchAt(src, ref image.Image, ox, oy int) bool {
 // search is used: a cheap top-left pixel scan followed by an expensive
 // byte-for-byte match only on promising candidates.
 func WaitWithTolerance(ctx context.Context, sc Screenshotter, expectedRect image.Rectangle, reference image.Image, radius int, pollDur time.Duration, newHash Hasher) (uint32, image.Rectangle, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return 0, image.Rectangle{}, err
 	}
@@ -681,7 +676,7 @@ func PixelFound(img image.Image, rect image.Rectangle, target color.RGBA, tolera
 // target. Returns the absolute (x, y) of the match. Tolerance is applied per
 // channel: |r-r'| ≤ tol && |g-g'| ≤ tol && |b-b'| ≤ tol.
 func FindColor(ctx context.Context, sc Screenshotter, rect image.Rectangle, target color.RGBA, tolerance int) (image.Point, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return image.Point{}, err
 	}
@@ -718,7 +713,7 @@ func abs(x int) int {
 // via exact pixel matching, or ctx expires. Returns the absolute rectangle
 // where the reference was located.
 func WaitForLocate(ctx context.Context, sc Screenshotter, searchArea image.Rectangle, reference image.Image, pollDur time.Duration) (image.Rectangle, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return image.Rectangle{}, err
 	}
@@ -748,7 +743,7 @@ func WaitForLocate(ctx context.Context, sc Screenshotter, searchArea image.Recta
 // each iteration so it can respect cancellation and inspect the image with
 // any predicate (brightness, color presence, histogram, etc.).
 func WaitForFn(ctx context.Context, sc Screenshotter, rect image.Rectangle, fn func(context.Context, image.Image) bool, pollDur time.Duration) (image.Image, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := checkAvailable(sc); err != nil {
 		return nil, err
 	}

--- a/input/misc_test.go
+++ b/input/misc_test.go
@@ -4,29 +4,31 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/nskaggs/perfuncted/ctxutil"
 )
 
-// ── normalizeContext ──────────────────────────────────────────────────────────
+// ── ctxutil.Default ──────────────────────────────────────────────────────────
 
 func TestNormalizeContext_NilReturnsBackground(t *testing.T) {
 	var nilCtx context.Context //nolint:SA1012 // testing nil handling
-	got := normalizeContext(nilCtx)
+	got := ctxutil.Default(nilCtx)
 	if got == nil {
-		t.Fatal("normalizeContext(nil) returned nil, want non-nil context")
+		t.Fatal("ctxutil.Default(nil) returned nil, want non-nil context")
 	}
 	// Should be equivalent to context.Background(): no deadline, never cancelled.
 	select {
 	case <-got.Done():
-		t.Fatal("normalizeContext(nil) returned a cancelled context")
+		t.Fatal("ctxutil.Default(nil) returned a cancelled context")
 	default:
 	}
 }
 
 func TestNormalizeContext_NonNilPassThrough(t *testing.T) {
 	ctx := context.Background()
-	got := normalizeContext(ctx)
+	got := ctxutil.Default(ctx)
 	if got != ctx {
-		t.Fatal("normalizeContext(non-nil) should return the same context")
+		t.Fatal("ctxutil.Default(non-nil) should return the same context")
 	}
 }
 

--- a/input/sleep.go
+++ b/input/sleep.go
@@ -3,17 +3,12 @@ package input
 import (
 	"context"
 	"time"
+
+	"github.com/nskaggs/perfuncted/ctxutil"
 )
 
-func normalizeContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
-}
-
 func sleepContext(ctx context.Context, d time.Duration) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if d <= 0 {
 		return ctx.Err()
 	}

--- a/input/uinput.go
+++ b/input/uinput.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/bendahl/uinput"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/keymap"
 )
 
@@ -136,7 +137,7 @@ func (b *UinputBackend) resolveKey(key string) (int, error) {
 }
 
 func (b *UinputBackend) KeyDown(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func (b *UinputBackend) KeyDown(ctx context.Context, key string) error {
 }
 
 func (b *UinputBackend) KeyUp(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -164,7 +165,7 @@ func (b *UinputBackend) Type(ctx context.Context, s string) error {
 }
 
 func (b *UinputBackend) TypeContext(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -200,7 +201,7 @@ func (b *UinputBackend) TypeContext(ctx context.Context, s string) error {
 // modifiers in reverse order. If any step fails, already-pressed modifiers
 // are released (best-effort) before the error is returned.
 func (b *UinputBackend) typeKeyWithMods(ctx context.Context, code int, down, up bool, mods modifiers) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -277,7 +278,7 @@ func (b *UinputBackend) typeKeyWithMods(ctx context.Context, code int, down, up 
 // to determine the correct evdev keycode and shift state for each rune.
 // This is layout-independent: on AZERTY 'a' is at KEY_Q position, on QWERTY it's KEY_A, etc.
 func (b *UinputBackend) typeText(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for _, ch := range s {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -307,7 +308,7 @@ func (b *UinputBackend) typeText(ctx context.Context, s string) error {
 }
 
 func (b *UinputBackend) MouseMove(ctx context.Context, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -315,7 +316,7 @@ func (b *UinputBackend) MouseMove(ctx context.Context, x, y int) error {
 }
 
 func (b *UinputBackend) MouseClick(ctx context.Context, x, y, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -329,7 +330,7 @@ func (b *UinputBackend) MouseClick(ctx context.Context, x, y, button int) error 
 }
 
 func (b *UinputBackend) MouseDown(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -352,7 +353,7 @@ func (b *UinputBackend) MouseDown(ctx context.Context, button int) error {
 }
 
 func (b *UinputBackend) MouseUp(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -387,7 +388,7 @@ func (b *UinputBackend) ensureMouse() error {
 }
 
 func (b *UinputBackend) ScrollUp(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -398,7 +399,7 @@ func (b *UinputBackend) ScrollUp(ctx context.Context, clicks int) error {
 }
 
 func (b *UinputBackend) ScrollDown(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -409,7 +410,7 @@ func (b *UinputBackend) ScrollDown(ctx context.Context, clicks int) error {
 }
 
 func (b *UinputBackend) ScrollLeft(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -420,7 +421,7 @@ func (b *UinputBackend) ScrollLeft(ctx context.Context, clicks int) error {
 }
 
 func (b *UinputBackend) ScrollRight(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -431,7 +432,7 @@ func (b *UinputBackend) ScrollRight(ctx context.Context, clicks int) error {
 }
 
 func (b *UinputBackend) PointerLocation(ctx context.Context) (int, int, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return 0, 0, err
 	}
@@ -439,7 +440,7 @@ func (b *UinputBackend) PointerLocation(ctx context.Context) (int, int, error) {
 }
 
 func (b *UinputBackend) Sync(ctx context.Context) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	return ctx.Err()
 }
 

--- a/input/wl_input_method.go
+++ b/input/wl_input_method.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
+
 	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
@@ -131,7 +133,7 @@ func (b *WlInputMethodBackend) Type(ctx context.Context, s string) error {
 // The input-method protocol (commit_string) requires compositor-side activation
 // which is unreliable in headless CI environments.
 func (b *WlInputMethodBackend) TypeContext(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -143,7 +145,7 @@ func (b *WlInputMethodBackend) TypeContext(ctx context.Context, s string) error 
 
 // Delegate other methods to the underlying backend when present.
 func (b *WlInputMethodBackend) KeyDown(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -153,7 +155,7 @@ func (b *WlInputMethodBackend) KeyDown(ctx context.Context, key string) error {
 	return b.other.KeyDown(ctx, key)
 }
 func (b *WlInputMethodBackend) KeyUp(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -163,7 +165,7 @@ func (b *WlInputMethodBackend) KeyUp(ctx context.Context, key string) error {
 	return b.other.KeyUp(ctx, key)
 }
 func (b *WlInputMethodBackend) MouseMove(ctx context.Context, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -173,7 +175,7 @@ func (b *WlInputMethodBackend) MouseMove(ctx context.Context, x, y int) error {
 	return b.other.MouseMove(ctx, x, y)
 }
 func (b *WlInputMethodBackend) MouseClick(ctx context.Context, x, y, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -183,7 +185,7 @@ func (b *WlInputMethodBackend) MouseClick(ctx context.Context, x, y, button int)
 	return b.other.MouseClick(ctx, x, y, button)
 }
 func (b *WlInputMethodBackend) MouseDown(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -193,7 +195,7 @@ func (b *WlInputMethodBackend) MouseDown(ctx context.Context, button int) error 
 	return b.other.MouseDown(ctx, button)
 }
 func (b *WlInputMethodBackend) MouseUp(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -203,7 +205,7 @@ func (b *WlInputMethodBackend) MouseUp(ctx context.Context, button int) error {
 	return b.other.MouseUp(ctx, button)
 }
 func (b *WlInputMethodBackend) ScrollUp(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -213,7 +215,7 @@ func (b *WlInputMethodBackend) ScrollUp(ctx context.Context, clicks int) error {
 	return b.other.ScrollUp(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollDown(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -223,7 +225,7 @@ func (b *WlInputMethodBackend) ScrollDown(ctx context.Context, clicks int) error
 	return b.other.ScrollDown(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollLeft(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -233,7 +235,7 @@ func (b *WlInputMethodBackend) ScrollLeft(ctx context.Context, clicks int) error
 	return b.other.ScrollLeft(ctx, clicks)
 }
 func (b *WlInputMethodBackend) ScrollRight(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -244,7 +246,7 @@ func (b *WlInputMethodBackend) ScrollRight(ctx context.Context, clicks int) erro
 }
 
 func (b *WlInputMethodBackend) PointerLocation(ctx context.Context) (int, int, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return 0, 0, err
 	}
@@ -255,7 +257,7 @@ func (b *WlInputMethodBackend) PointerLocation(ctx context.Context) (int, int, e
 }
 
 func (b *WlInputMethodBackend) Sync(ctx context.Context) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/input/wl_keyboard.go
+++ b/input/wl_keyboard.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/keymap"
 	"github.com/nskaggs/perfuncted/internal/shmutil"
 	"github.com/nskaggs/perfuncted/internal/wl"
@@ -166,7 +167,7 @@ func (k *wlKeyboard) clearTempModsBestEffort(modBitmask uint32) {
 // Text and key actions are executed in the order they appear in the input,
 // so "Hello{enter}" types "Hello" before pressing Enter.
 func (k *wlKeyboard) sendkeys(ctx context.Context, actions []keySend) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if len(actions) == 0 {
 		return nil
 	}
@@ -563,7 +564,7 @@ func (k *wlKeyboard) sendModifiers() error {
 }
 
 func (k *wlKeyboard) tap(ctx context.Context, keycode uint32) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/input/wl_keyboard_test.go
+++ b/input/wl_keyboard_test.go
@@ -198,7 +198,7 @@ func TestUploadKeymap_Caching(t *testing.T) {
 
 func TestSendkeys_Empty(t *testing.T) {
 	k, rc := newSendkeysTestKeyboard()
-		if err := k.sendkeys(context.Background(), nil); err != nil {
+	if err := k.sendkeys(context.Background(), nil); err != nil {
 		t.Fatalf("sendkeys(nil): %v", err)
 	}
 	if rc.writes != 0 {
@@ -215,7 +215,7 @@ func TestSendkeys_Empty(t *testing.T) {
 func TestSendkeys_PlainText(t *testing.T) {
 	k, rc := newSendkeysTestKeyboard()
 	actions := []keySend{{text: "ab"}}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// 1 keymap upload + 4 key events (2 chars × press+release) = 5 writes
@@ -241,7 +241,7 @@ func TestSendkeys_ComboOnly(t *testing.T) {
 	actions := []keySend{
 		{key: "enter", modifiers: modifiers{}},
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// 1 keymap upload + 2 key events (press+release of enter) = 3 writes
@@ -256,7 +256,7 @@ func TestSendkeys_ExplicitModifierReleaseOnlySendsKeyUp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseKeySend: %v", err)
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	if rc.writes != 5 {
@@ -283,7 +283,7 @@ func TestSendkeys_TextBeforeCombo_OrderedCorrectly(t *testing.T) {
 		{text: "ab"},
 		{key: "enter"},
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// 1 keymap upload + 4 key events for "ab" + 2 key events for enter = 7 writes
@@ -309,7 +309,7 @@ func TestSendkeys_ComboBeforeText_OrderedCorrectly(t *testing.T) {
 		{key: "enter"},
 		{text: "ab"},
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// 1 keymap upload + 2 key events for enter + 4 key events for "ab" = 7 writes
@@ -332,7 +332,7 @@ func TestSendkeys_ModifierCombo(t *testing.T) {
 	actions := []keySend{
 		{key: "a", modifiers: modifiers{ctrl: true}},
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// Expected writes:
@@ -365,7 +365,7 @@ func TestSendkeys_MixedTextAndCombo_AllRunesInKeymap(t *testing.T) {
 		{key: "enter"},
 		{text: "World"},
 	}
-	if err := k.sendkeys(context.Background(),actions); err != nil {
+	if err := k.sendkeys(context.Background(), actions); err != nil {
 		t.Fatalf("sendkeys: %v", err)
 	}
 	// Total: 1 keymap + 4 for Hi + 2 for enter + 10 for World = 17

--- a/input/wl_virtual.go
+++ b/input/wl_virtual.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/wl"
 )
 
@@ -170,7 +171,7 @@ func (b *WlVirtualBackend) ptrFrame() error {
 // MouseMove moves the pointer to absolute position (x, y) in the compositor's
 // output coordinate space (i.e. sway display pixels).
 func (b *WlVirtualBackend) MouseMove(ctx context.Context, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -192,7 +193,7 @@ func (b *WlVirtualBackend) MouseMove(ctx context.Context, x, y int) error {
 }
 
 func (b *WlVirtualBackend) button(ctx context.Context, code, state uint32) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -234,7 +235,7 @@ func (b *WlVirtualBackend) MouseUp(ctx context.Context, button int) error {
 
 // MouseClick moves to (x,y) then clicks the given button.
 func (b *WlVirtualBackend) MouseClick(ctx context.Context, x, y, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -261,7 +262,7 @@ func (b *WlVirtualBackend) Type(ctx context.Context, s string) error {
 }
 
 func (b *WlVirtualBackend) TypeContext(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -277,7 +278,7 @@ func (b *WlVirtualBackend) TypeContext(ctx context.Context, s string) error {
 // KeyDown presses and holds a key. Modifier keys update the compositor's
 // modifier state; other keys are held until released with KeyUp.
 func (b *WlVirtualBackend) KeyDown(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -288,7 +289,7 @@ func (b *WlVirtualBackend) KeyDown(ctx context.Context, key string) error {
 
 // KeyUp releases a previously held key.
 func (b *WlVirtualBackend) KeyUp(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -301,7 +302,7 @@ func (b *WlVirtualBackend) KeyUp(ctx context.Context, key string) error {
 // axis 0 = vertical, axis 1 = horizontal. Positive values scroll down/right;
 // negative values scroll up/left.
 func (b *WlVirtualBackend) scroll(ctx context.Context, axis uint32, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -344,7 +345,7 @@ func (b *WlVirtualBackend) ScrollRight(ctx context.Context, clicks int) error {
 }
 
 func (b *WlVirtualBackend) PointerLocation(ctx context.Context) (int, int, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return 0, 0, err
 	}
@@ -352,7 +353,7 @@ func (b *WlVirtualBackend) PointerLocation(ctx context.Context) (int, int, error
 }
 
 func (b *WlVirtualBackend) Sync(ctx context.Context) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	return ctx.Err()
 }
 

--- a/input/wlkeyboard_keyevents_test.go
+++ b/input/wlkeyboard_keyevents_test.go
@@ -218,7 +218,7 @@ func TestUploadKeymapAndRestoreMods_NoMods(t *testing.T) {
 
 func TestTypeString_Empty(t *testing.T) {
 	k, rc := newTestKeyboard()
-	if err := 	k.typeString(context.Background(), ""); err != nil {
+	if err := k.typeString(context.Background(), ""); err != nil {
 		t.Fatalf("typeString: %v", err)
 	}
 	if rc.writes != 0 {

--- a/input/xtest.go
+++ b/input/xtest.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jezek/xgb/xproto"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/x11"
 )
 
@@ -155,7 +156,7 @@ func (b *XTestBackend) keycodeFor(key string) (xproto.Keycode, error) {
 }
 
 func (b *XTestBackend) KeyDown(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -168,7 +169,7 @@ func (b *XTestBackend) KeyDown(ctx context.Context, key string) error {
 
 // KeyUp releases a previously held key.
 func (b *XTestBackend) KeyUp(ctx context.Context, key string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -184,7 +185,7 @@ func (b *XTestBackend) Type(ctx context.Context, s string) error {
 }
 
 func (b *XTestBackend) TypeContext(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -289,7 +290,7 @@ func (b *XTestBackend) TypeContext(ctx context.Context, s string) error {
 // GetKeyboardMapping reply; Shift is held when the keysym lives at level >= 1.
 // This is layout-independent: the X server tells us which keysyms need Shift.
 func (b *XTestBackend) typeText(ctx context.Context, s string) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for _, ch := range s {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -350,7 +351,7 @@ func (b *XTestBackend) keyUpKC(_ context.Context, kc xproto.Keycode) error {
 }
 
 func (b *XTestBackend) MouseMove(ctx context.Context, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -359,7 +360,7 @@ func (b *XTestBackend) MouseMove(ctx context.Context, x, y int) error {
 }
 
 func (b *XTestBackend) MouseClick(ctx context.Context, x, y, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -379,7 +380,7 @@ func (b *XTestBackend) MouseClick(ctx context.Context, x, y, button int) error {
 }
 
 func (b *XTestBackend) MouseDown(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -388,7 +389,7 @@ func (b *XTestBackend) MouseDown(ctx context.Context, button int) error {
 }
 
 func (b *XTestBackend) MouseUp(ctx context.Context, button int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -399,7 +400,7 @@ func (b *XTestBackend) MouseUp(ctx context.Context, button int) error {
 // ScrollUp scrolls the mouse wheel up by the given number of notches.
 // X11 scroll is button 4 (up) / 5 (down).
 func (b *XTestBackend) ScrollUp(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for i := 0; i < clicks; i++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -416,7 +417,7 @@ func (b *XTestBackend) ScrollUp(ctx context.Context, clicks int) error {
 
 // ScrollDown scrolls the mouse wheel down by the given number of notches.
 func (b *XTestBackend) ScrollDown(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for i := 0; i < clicks; i++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -434,7 +435,7 @@ func (b *XTestBackend) ScrollDown(ctx context.Context, clicks int) error {
 // ScrollLeft scrolls the mouse wheel left by the given number of notches.
 // X11 scroll is button 6 (left) / 7 (right).
 func (b *XTestBackend) ScrollLeft(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for i := 0; i < clicks; i++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -451,7 +452,7 @@ func (b *XTestBackend) ScrollLeft(ctx context.Context, clicks int) error {
 
 // ScrollRight scrolls the mouse wheel right by the given number of notches.
 func (b *XTestBackend) ScrollRight(ctx context.Context, clicks int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	for i := 0; i < clicks; i++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -467,7 +468,7 @@ func (b *XTestBackend) ScrollRight(ctx context.Context, clicks int) error {
 }
 
 func (b *XTestBackend) PointerLocation(ctx context.Context) (int, int, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return 0, 0, err
 	}
@@ -479,7 +480,7 @@ func (b *XTestBackend) PointerLocation(ctx context.Context) (int, int, error) {
 }
 
 func (b *XTestBackend) Sync(ctx context.Context) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/perfuncted.go
+++ b/perfuncted.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/nskaggs/perfuncted/clipboard"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/input"
 	"github.com/nskaggs/perfuncted/internal/compositor"
 	"github.com/nskaggs/perfuncted/internal/env"
@@ -192,7 +193,7 @@ func (p *Perfuncted) Paste(ctx context.Context, text string) error {
 	if p == nil {
 		return fmt.Errorf("perfuncted: nil Perfuncted")
 	}
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	p.traceAction(fmt.Sprintf("paste text=%q", text))
 	if p.Clipboard.Clipboard != nil {
 		return p.Clipboard.pasteWithInputContext(ctx, text, p.Input)
@@ -283,7 +284,7 @@ func (p *Perfuncted) Close() error {
 }
 
 func Retry(ctx context.Context, poll time.Duration, fn func() error) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if fn == nil {
 		return fmt.Errorf("retry: nil function")
 	}
@@ -311,11 +312,4 @@ func (p *Perfuncted) traceAction(msg string) {
 		return
 	}
 	p.trace.Tracef("perfuncted", "%s", msg)
-}
-
-func normalizeContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
 }

--- a/screen/kwinshot.go
+++ b/screen/kwinshot.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/find"
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
@@ -132,9 +133,7 @@ func (t *kwinDBusTransport) CaptureActiveScreen(ctx context.Context) (image.Imag
 }
 
 func (t *kwinDBusTransport) capture(ctx context.Context, method string, rect image.Rectangle, args ...interface{}) (image.Image, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("screen/kwin: capture canceled: %w", err)
 	}

--- a/screen/portal_dbus.go
+++ b/screen/portal_dbus.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/find"
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
@@ -141,9 +142,7 @@ func NewPortalDBusBackendForBus(addr string) (*PortalDBusBackend, error) {
 // Grab takes a full workspace screenshot via the portal and returns the
 // requested rectangle. The portal may show a consent dialog on first use.
 func (b *PortalDBusBackend) Grab(ctx context.Context, rect image.Rectangle) (image.Image, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("screen/portal: grab canceled: %w", err)
 	}

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"strings"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/compositor"
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 	"github.com/nskaggs/perfuncted/internal/env"
@@ -35,9 +36,7 @@ func ResolutionWithContext(ctx context.Context, sc Screenshotter) (int, int, err
 	if err := util.CheckAvailable("screen", sc); err != nil {
 		return 0, 0, err
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	if r, ok := sc.(Resolver); ok {
 		return r.Resolution()
 	}

--- a/window/find.go
+++ b/window/find.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/util"
 )
 
@@ -25,9 +26,7 @@ func find(ctx context.Context, m Manager, match Matcher, label string) (Info, er
 	if err := util.CheckAvailable("window", m); err != nil {
 		return Info{}, err
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	for w, err := range m.IterateWindows(ctx) {
 		if err != nil {
 			return Info{}, err
@@ -52,9 +51,7 @@ func WaitFor(ctx context.Context, m Manager, pattern string, poll time.Duration)
 
 // WaitForMatch blocks until a window matching match is found, or ctx expires.
 func WaitForMatch(ctx context.Context, m Manager, match Match, poll time.Duration) (Info, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	compiled := CompileMatch(match)
 	label := match.String()
 	ticker := time.NewTicker(clampPoll(poll))
@@ -86,9 +83,7 @@ func WaitForClose(ctx context.Context, m Manager, pattern string, poll time.Dura
 
 // WaitForMatchClose blocks until no window matches match, or ctx expires.
 func WaitForMatchClose(ctx context.Context, m Manager, match Match, poll time.Duration) error {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	compiled := CompileMatch(match)
 	label := match.String()
 	ticker := time.NewTicker(clampPoll(poll))

--- a/window/kwinscript.go
+++ b/window/kwinscript.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"github.com/nskaggs/perfuncted/internal/dbusutil"
 )
 
@@ -93,9 +94,7 @@ func (r *pfReceiver) ReportWindows(data string) *dbus.Error {
 //
 // where svc is the value passed to buildJS.
 func (k *KWinScriptManager) runScript(ctx context.Context, buildJS func(svc string) string) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}

--- a/window/sway.go
+++ b/window/sway.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"net"
 	"path/filepath"
+
+	"github.com/nskaggs/perfuncted/ctxutil"
 	"sync"
 	"time"
 
@@ -100,7 +102,7 @@ func swayQueryDeadline(ctx context.Context) time.Time {
 }
 
 func swayQueryConn(ctx context.Context, conn net.Conn, msgType uint32, payload string) ([]byte, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -146,7 +148,7 @@ func swayQueryConn(ctx context.Context, conn net.Conn, msgType uint32, payload s
 }
 
 func (m *SwayManager) query(ctx context.Context, msgType uint32, payload string) ([]byte, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -175,13 +177,6 @@ func (m *SwayManager) query(ctx context.Context, msgType uint32, payload string)
 		return nil, err
 	}
 	return body, nil
-}
-
-func normalizeContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
 }
 
 // List returns all visible windows (leaf containers) in the sway tree.
@@ -318,7 +313,7 @@ func (m *SwayManager) Restore(ctx context.Context, substr string) error {
 // Move repositions the first window whose title contains substr.
 // The window is made floating so it can be placed at an absolute position.
 func (m *SwayManager) Move(ctx context.Context, substr string, x, y int) error {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	w, err := m.findWindow(ctx, substr)
 	if err != nil {
 		return err
@@ -444,7 +439,7 @@ var swayDialContext = func(ctx context.Context, network, address string) (net.Co
 }
 
 func swayQueryOnceContext(ctx context.Context, sock string, msgType uint32, payload string) ([]byte, error) {
-	ctx = normalizeContext(ctx)
+	ctx = ctxutil.Default(ctx)
 	conn, err := swayDialContext(ctx, "unix", sock)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {


### PR DESCRIPTION
Extract the duplicated normalizeContext function from across the codebase into a new public package perfuncted/ctxutil with a single Default(ctx) function.