### PR TITLE
transport: classify 'context deadline exceeded' string match

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -46,6 +46,8 @@ func Classify(err error) Classification {
 		return ClassConnectionClosed
 	case strings.Contains(msg, "i/o timeout"):
 		return ClassTimeout
+	case strings.Contains(msg, "context deadline exceeded"):
+		return ClassTimeout
 	default:
 		return ClassUnknown
 	}

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -15,6 +15,7 @@ var (
 	errHTTPNotFound           = errors.New("404 not found")
 	errBareConnectionReset    = errors.New("connection reset by peer")
 	errBareClosedNetwork      = errors.New("closed network connection")
+	errContextDeadlineStr    = errors.New("operation failed: context deadline exceeded")
 	errUnexpectedScriptResult = errors.New("unexpected script result")
 )
 
@@ -28,6 +29,7 @@ func TestClassify(t *testing.T) {
 		{name: "deadline exceeded", err: context.DeadlineExceeded, want: ClassTimeout},
 		{name: "wrapped deadline exceeded", err: fmt.Errorf("read: %w", context.DeadlineExceeded), want: ClassTimeout},
 		{name: "io timeout", err: errIOTimeout, want: ClassTimeout},
+		{name: "context deadline string", err: errContextDeadlineStr, want: ClassTimeout},
 		{name: "broken pipe", err: errBrokenPipe, want: ClassConnectionReset},
 		{name: "connection reset", err: errConnectionReset, want: ClassConnectionReset},
 		{name: "closed connection", err: errClosedNetwork, want: ClassConnectionClosed},

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -15,7 +15,7 @@ var (
 	errHTTPNotFound           = errors.New("404 not found")
 	errBareConnectionReset    = errors.New("connection reset by peer")
 	errBareClosedNetwork      = errors.New("closed network connection")
-	errContextDeadlineStr    = errors.New("operation failed: context deadline exceeded")
+	errContextDeadlineStr     = errors.New("operation failed: context deadline exceeded")
 	errUnexpectedScriptResult = errors.New("unexpected script result")
 )
 


### PR DESCRIPTION
Adds string matching for 'context deadline exceeded' in addition to the existing errors.Is check, covering wrapped errors that don't support unwrapping.