### PR TITLE
Deduplicate clamp: export poll.Clamp, remove find.clampPoll

### DIFF
--- a/find/find.go
+++ b/find/find.go
@@ -39,13 +39,6 @@ type Hasher func() hash.Hash32
 // DefaultHasher uses CRC32 IEEE.
 var DefaultHasher Hasher = crc32.NewIEEE
 
-func clampPoll(poll time.Duration) time.Duration {
-	if poll <= 0 {
-		return 10 * time.Millisecond
-	}
-	return poll
-}
-
 func contextErr(ctx context.Context) error {
 	if ctx == nil {
 		return nil
@@ -190,7 +183,7 @@ func poll(ctx context.Context, pollDur time.Duration, onCancel uint32, fn func(a
 		}
 	}
 
-	ticker := time.NewTicker(clampPoll(pollDur))
+	ticker := time.NewTicker(pollpkg.Clamp(pollDur))
 	defer ticker.Stop()
 	for {
 		if err := contextErr(ctx); err != nil {
@@ -379,7 +372,7 @@ func ScanFor(ctx context.Context, sc Screenshotter, rects []image.Rectangle, wan
 	bboxArea := bbox.Dx() * bbox.Dy()
 	useBbox := bboxArea <= 2*totalArea
 
-	ticker := time.NewTicker(clampPoll(poll))
+	ticker := time.NewTicker(pollpkg.Clamp(poll))
 	defer ticker.Stop()
 
 	for {

--- a/find/find_errs_test.go
+++ b/find/find_errs_test.go
@@ -7,6 +7,8 @@ import (
 	"image/color"
 	"testing"
 	"time"
+
+	pollpkg "github.com/nskaggs/perfuncted/poll"
 )
 
 // errScreen always returns an error from Grab.
@@ -308,23 +310,23 @@ func TestWaitWithTolerance_NoSubImage_Timeout(t *testing.T) {
 // ── clampPoll ─────────────────────────────────────────────────────────────────
 
 func TestClampPoll_ZeroReturnsDefault(t *testing.T) {
-	got := clampPoll(0)
+	got := pollpkg.Clamp(0)
 	if got != 10*time.Millisecond {
-		t.Fatalf("clampPoll(0) = %v, want 10ms", got)
+		t.Fatalf("Clamp(0) = %v, want 10ms", got)
 	}
 }
 
 func TestClampPoll_NegativeReturnsDefault(t *testing.T) {
-	got := clampPoll(-1)
+	got := pollpkg.Clamp(-1)
 	if got != 10*time.Millisecond {
-		t.Fatalf("clampPoll(-1) = %v, want 10ms", got)
+		t.Fatalf("Clamp(-1) = %v, want 10ms", got)
 	}
 }
 
 func TestClampPoll_PositivePassThrough(t *testing.T) {
-	got := clampPoll(50 * time.Millisecond)
+	got := pollpkg.Clamp(50 * time.Millisecond)
 	if got != 50*time.Millisecond {
-		t.Fatalf("clampPoll(50ms) = %v, want 50ms", got)
+		t.Fatalf("Clamp(50ms) = %v, want 50ms", got)
 	}
 }
 

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -35,7 +35,7 @@ func AdaptivePoll(attempt int, base, max time.Duration) time.Duration {
 	return d
 }
 
-func clamp(d time.Duration) time.Duration {
+func Clamp(d time.Duration) time.Duration {
 	if d <= 0 {
 		return 10 * time.Millisecond
 	}
@@ -50,7 +50,7 @@ func WaitFunc[T any](ctx context.Context, pollInterval time.Duration, fn func() 
 		var zero T
 		return zero, fmt.Errorf("poll.WaitFunc: %w", ErrNilFunction)
 	}
-	pollInterval = clamp(pollInterval)
+	pollInterval = Clamp(pollInterval)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
poll.go had an unexported clamp function identical to find.go's clampPoll. Export it as poll.Clamp and migrate find.go to use it.