### PR TITLE
Optimize screenshot pixel scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,25 @@ env:
   CGO_ENABLED: "0"
 
 jobs:
+  performance:
+    name: Race & Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.3"
+          cache: true
+      - name: Run race detector
+        run: go test -race -short ./...
+      - name: Run core benchmarks
+        run: go test ./find -run '^$' -bench 'Pixel(Hash|Found)' -benchmem -count=5 | tee benchmarks.txt
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmarks.txt
+
   quality:
     name: Build & Quality
     runs-on: ubuntu-latest

--- a/find/find.go
+++ b/find/find.go
@@ -641,6 +641,25 @@ func PixelFound(img image.Image, rect image.Rectangle, target color.RGBA, tolera
 		return image.Point{}, false
 	}
 
+	// NRGBA is the native layout returned by several screenshot backends.
+	// Scan its Pix buffer directly; calling At and converting through
+	// color.RGBAModel allocates for every pixel.
+	if nrgba, ok := img.(*image.NRGBA); ok {
+		for y := b.Min.Y; y < b.Max.Y; y++ {
+			off := (y-nrgba.Rect.Min.Y)*nrgba.Stride + (b.Min.X-nrgba.Rect.Min.X)*4
+			for x := b.Min.X; x < b.Max.X; x++ {
+				_ = nrgba.Pix[off+3]
+				if abs(int(nrgba.Pix[off])-int(target.R)) <= tolerance &&
+					abs(int(nrgba.Pix[off+1])-int(target.G)) <= tolerance &&
+					abs(int(nrgba.Pix[off+2])-int(target.B)) <= tolerance {
+					return image.Pt(rect.Min.X+x-b.Min.X, rect.Min.Y+y-b.Min.Y), true
+				}
+				off += 4
+			}
+		}
+		return image.Point{}, false
+	}
+
 	// Slow path: generic image via At() + colour model conversion.
 	for y := b.Min.Y; y < b.Max.Y; y++ {
 		for x := b.Min.X; x < b.Max.X; x++ {

--- a/find/find_slowpath_test.go
+++ b/find/find_slowpath_test.go
@@ -219,13 +219,13 @@ func BenchmarkPixelFound_FastPath(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PixelFound(img, rect, target, 0)
 	}
 }
 
-// BenchmarkPixelFound_SlowPath benchmarks PixelFound with *image.NRGBA (slow path).
-func BenchmarkPixelFound_SlowPath(b *testing.B) {
+// BenchmarkPixelFound_NRGBA benchmarks the native screenshot image layout.
+func BenchmarkPixelFound_NRGBA(b *testing.B) {
 	img := solidNRGBA(256, 256, color.RGBA{R: 80, G: 80, B: 80, A: 255})
 	img.SetNRGBA(200, 200, color.NRGBA{R: 255, G: 0, B: 0, A: 255})
 	target := color.RGBA{R: 255, G: 0, B: 0, A: 255}
@@ -233,7 +233,19 @@ func BenchmarkPixelFound_SlowPath(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PixelFound(img, rect, target, 0)
+	}
+}
+
+func TestPixelFoundNRGBAAllocations(t *testing.T) {
+	img := solidNRGBA(256, 256, color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	target := color.RGBA{R: 255, G: 0, B: 0, A: 255}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _ = PixelFound(img, img.Bounds(), target, 0)
+	})
+	if allocs != 0 {
+		t.Fatalf("PixelFound NRGBA allocations = %v, want 0", allocs)
 	}
 }


### PR DESCRIPTION
Optimize native NRGBA pixel scans, enforce zero allocations, and add race plus benchmark CI coverage.