### PR TITLE
Enable cgo for race CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           go-version: "1.26.3"
           cache: true
       - name: Run race detector
+        env:
+          CGO_ENABLED: "1"
         run: go test -race -short ./...
       - name: Run core benchmarks
         run: go test ./find -run '^$' -bench 'Pixel(Hash|Found)' -benchmem -count=5 | tee benchmarks.txt


### PR DESCRIPTION
Enable cgo for the race-detector job.